### PR TITLE
[Feat#70] 채팅 필터링 추가 처리

### DIFF
--- a/src/main/java/com/mindmate/mindmate_server/chat/controller/AdminFilteringController.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/controller/AdminFilteringController.java
@@ -1,0 +1,35 @@
+package com.mindmate.mindmate_server.chat.controller;
+
+import com.mindmate.mindmate_server.chat.dto.UserFilteringHistoryDTO;
+import com.mindmate.mindmate_server.chat.service.AdminFilteringService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/filtering")
+public class AdminFilteringController {
+    private final AdminFilteringService adminFilteringService;
+
+    /**
+     * 사용자별 필터링 이력 조회
+     */
+    @GetMapping("/users/{userId}")
+    public ResponseEntity<UserFilteringHistoryDTO> getUserFilteringHistory(@PathVariable Long userId) {
+        return ResponseEntity.ok(adminFilteringService.getUserFilteringHistory(userId));
+    }
+
+    /**
+     * 전체 필터링 이력 조회
+     */
+    @GetMapping("/users")
+    public ResponseEntity<List<UserFilteringHistoryDTO>> getUserFilteringHistories() {
+        return ResponseEntity.ok(adminFilteringService.getUserFilteringHistories());
+    }
+}

--- a/src/main/java/com/mindmate/mindmate_server/chat/dto/FilteredContentDTO.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/dto/FilteredContentDTO.java
@@ -1,0 +1,15 @@
+package com.mindmate.mindmate_server.chat.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class FilteredContentDTO {
+    private Long roomId;
+    private String content;
+}

--- a/src/main/java/com/mindmate/mindmate_server/chat/dto/UserFilteringHistoryDTO.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/dto/UserFilteringHistoryDTO.java
@@ -1,0 +1,24 @@
+package com.mindmate.mindmate_server.chat.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserFilteringHistoryDTO {
+    private Long userId;
+    private String email;
+    private String nickname;
+    private Map<Long, Integer> roomFilterCounts;
+    private List<FilteredContentDTO> recentFilteredContents;
+    private int totalFilterCount;
+    private Date lastFilteringTime;
+}

--- a/src/main/java/com/mindmate/mindmate_server/chat/service/AdminFilteringService.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/service/AdminFilteringService.java
@@ -1,0 +1,94 @@
+package com.mindmate.mindmate_server.chat.service;
+
+import com.mindmate.mindmate_server.chat.dto.FilteredContentDTO;
+import com.mindmate.mindmate_server.chat.dto.UserFilteringHistoryDTO;
+import com.mindmate.mindmate_server.global.util.RedisKeyManager;
+import com.mindmate.mindmate_server.user.domain.User;
+import com.mindmate.mindmate_server.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AdminFilteringService {
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final RedisKeyManager redisKeyManager;
+    private final UserService userService;
+
+    public UserFilteringHistoryDTO getUserFilteringHistory(Long userId) {
+        // 사용자가 참여한 모든 채팅방의 필터링 카운트 키 조회 -> 24시간 이내 필터링이 걸린 채팅방임
+        Set<String> filteringCountKeys = redisTemplate.keys(redisKeyManager.getFilteringCountKey(userId, "*"));
+        Map<Long, Integer> roomFilterCounts = new HashMap<>();
+        List<FilteredContentDTO> recentFilteredContents = new ArrayList<>();
+
+        // 채팅방별로 필터링 횟수 및 내용 조회
+        for (String key : filteringCountKeys) {
+            String roomIdStr = key.substring(key.lastIndexOf(":") + 1);
+            Long roomId = Long.parseLong(roomIdStr);
+
+            Object count = redisTemplate.opsForValue().get(key);
+            if (count != null) {
+                roomFilterCounts.put(roomId, Integer.parseInt(count.toString()));
+            }
+
+            String contentKey = redisKeyManager.getFilteringContentKey(userId, roomId);
+            List<Object> contents = redisTemplate.opsForList().range(contentKey, 0, -1);
+            Set<String> uniqueContents = new LinkedHashSet<>(); // 순서 유지
+
+            if (contents != null && !contents.isEmpty()) {
+                for (Object content : contents) {
+                    String contentStr = content.toString();
+                    if (uniqueContents.add(contentStr)) { // 중복이 아닌 경우에만 추가
+                        recentFilteredContents.add(new FilteredContentDTO(roomId, contentStr));
+                    }
+                }
+            }
+        }
+
+        User user = userService.findUserById(userId);
+
+        return UserFilteringHistoryDTO.builder()
+                .userId(userId)
+                .email(user.getEmail())
+                .nickname(user.getProfile().getNickname())
+                .roomFilterCounts(roomFilterCounts)
+                .recentFilteredContents(recentFilteredContents)
+                .totalFilterCount(roomFilterCounts.values().stream().mapToInt(Integer::intValue).sum())
+                .build();
+    }
+
+    public List<UserFilteringHistoryDTO> getUserFilteringHistories() {
+        Set<String> allFilteringCountKeys = redisTemplate.keys("filtering:count:*");
+        Set<Long> userIds = new HashSet<>();
+
+        for (String key : allFilteringCountKeys) {
+            try {
+                String[] parts = key.split(":");
+                if (parts.length >= 3) {
+                    userIds.add(Long.parseLong(parts[2]));
+                }
+            } catch (Exception e) {
+                log.error("Error extracting user ID from key: {}", key);
+            }
+        }
+
+        // 각 사용자의 필터링 이력 조회
+        List<UserFilteringHistoryDTO> results = new ArrayList<>();
+        for (Long userId : userIds) {
+            try {
+                results.add(getUserFilteringHistory(userId));
+            } catch (Exception e) {
+                log.error("Error getting filtering history for user {}: {}", userId, e.getMessage());
+            }
+        }
+
+        results.sort((a, b) -> Integer.compare(b.getTotalFilterCount(), a.getTotalFilterCount()));
+
+        return results;
+    }
+}

--- a/src/main/java/com/mindmate/mindmate_server/chat/service/FilteringEventConsumer.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/service/FilteringEventConsumer.java
@@ -2,9 +2,7 @@ package com.mindmate.mindmate_server.chat.service;
 
 import com.mindmate.mindmate_server.chat.dto.ChatMessageEvent;
 import com.mindmate.mindmate_server.global.util.RedisKeyManager;
-import com.mindmate.mindmate_server.global.util.SlackNotifier;
-import com.mindmate.mindmate_server.user.domain.User;
-import com.mindmate.mindmate_server.user.service.UserService;
+import com.mindmate.mindmate_server.user.service.AdminUserSuspensionService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -20,9 +18,8 @@ import java.util.concurrent.TimeUnit;
 @RequiredArgsConstructor
 public class FilteringEventConsumer {
     private final RedisTemplate<String, Object> redisTemplate;
-    private final UserService userService;
     private final RedisKeyManager redisKeyManager;
-    private final SlackNotifier slackNotifier;
+    private final AdminUserSuspensionService suspensionService;
 
     private static final int CHAT_FILTERING_SUSPENSION_THRESHOLD = 5; // 필터링 정지 횟수
     private static final int CHAT_FILTERING_SUSPENSION_TIME = 2; // 정지 시간
@@ -70,20 +67,10 @@ public class FilteringEventConsumer {
     }
 
     private void applySuspension(Long userId) {
-        User user = userService.findUserById(userId);
-
-        Duration suspensionDuration = Duration.ofHours(CHAT_FILTERING_SUSPENSION_TIME);
-        user.suspend(suspensionDuration);
-        userService.save(user);
-
-        String suspensionKey = redisKeyManager.getUserSuspensionKey(userId);
-        redisTemplate.opsForValue().set(suspensionKey, "suspended");
-        redisTemplate.expire(suspensionKey, CHAT_FILTERING_SUSPENSION_TIME, TimeUnit.HOURS);
-
-        slackNotifier.sendSuspensionAlert(
-                user,
-                "채팅 필터링 위반 (5회 이상)",
-                suspensionDuration
-        );
+        suspensionService.suspendUser(
+                userId,
+                -1,
+                Duration.ofHours(CHAT_FILTERING_SUSPENSION_TIME),
+                "채팅 필터링 위반 (5회 이상)");
     }
 }

--- a/src/main/java/com/mindmate/mindmate_server/chat/service/FilteringEventConsumer.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/service/FilteringEventConsumer.java
@@ -1,0 +1,78 @@
+package com.mindmate.mindmate_server.chat.service;
+
+import com.mindmate.mindmate_server.chat.dto.ChatMessageEvent;
+import com.mindmate.mindmate_server.global.util.RedisKeyManager;
+import com.mindmate.mindmate_server.user.domain.User;
+import com.mindmate.mindmate_server.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class FilteringEventConsumer {
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final UserService userService;
+    private final RedisKeyManager redisKeyManager;
+
+    private static final int CHAT_FILTERING_SUSPENSION_THRESHOLD = 5; // 필터링 정지 횟수
+    private static final int CHAT_FILTERING_SUSPENSION_TIME = 2; // 정지 시간
+    private static final int CHAT_FILTERING_EXPIRY_HOURS = 24; // 해당 레디스 값 유효 시간
+
+    @KafkaListener(
+            topics = "chat-message-topic",
+            groupId = "filtering-event-group",
+            containerFactory = "chatMessageListenerContainerFactory"
+    )
+    public void processFilteringEvent(ConsumerRecord<String, ChatMessageEvent> record) {
+        ChatMessageEvent event = record.value();
+
+        if (!event.isFiltered() || event.getSenderId() == null) {
+            return;
+        }
+
+        try {
+            String filteringCountKey = redisKeyManager.getFilteringCountKey(event.getSenderId(), event.getRoomId());
+            String filteringContentKey = redisKeyManager.getFilteringContentKey(event.getSenderId(), event.getRoomId());
+
+            Long count = redisTemplate.opsForValue().increment(filteringCountKey, 1);
+
+            // 첫 필터링 발생 -> count 값 24시간 만료 설정
+            if (count != null && count == 1) {
+                redisTemplate.expire(filteringCountKey, CHAT_FILTERING_EXPIRY_HOURS, TimeUnit.HOURS);
+            }
+
+            String truncatedContent = event.getContent().length() > 100 ? event.getContent().substring(0, 100) + "..." : event.getContent();
+            redisTemplate.opsForList().leftPush(filteringContentKey, truncatedContent);
+            redisTemplate.opsForList().trim(filteringContentKey, 0, 4);
+            redisTemplate.expire(filteringContentKey, CHAT_FILTERING_EXPIRY_HOURS, TimeUnit.HOURS);
+
+            if (count != null && count >= CHAT_FILTERING_SUSPENSION_THRESHOLD) {
+//            redisTemplate.expire(filteringContentKey, )
+                applySuspension(event.getSenderId());
+
+                redisTemplate.delete(filteringCountKey);
+                log.info("User {} reached filtering threshold in room {}. Applied suspension.",
+                        event.getSenderId(), event.getRoomId());
+            }
+        } catch (Exception e) {
+            log.error("Error processing filtering event: {}", e.getMessage(), e);
+        }
+    }
+
+    private void applySuspension(Long userId) {
+        User user = userService.findUserById(userId);
+
+        user.suspend(Duration.ofHours(CHAT_FILTERING_SUSPENSION_TIME));
+        userService.save(user);
+
+        // todo: 정지 시간을 reids에서 기록해서 정지 해제 스케줄러에서 사용?
+    }
+}

--- a/src/main/java/com/mindmate/mindmate_server/chat/service/FilteringEventConsumer.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/service/FilteringEventConsumer.java
@@ -73,6 +73,8 @@ public class FilteringEventConsumer {
         user.suspend(Duration.ofHours(CHAT_FILTERING_SUSPENSION_TIME));
         userService.save(user);
 
-        // todo: 정지 시간을 reids에서 기록해서 정지 해제 스케줄러에서 사용?
+        String suspensionKey = redisKeyManager.getUserSuspensionKey(userId);
+        redisTemplate.opsForValue().set(suspensionKey, "suspended");
+        redisTemplate.expire(suspensionKey, CHAT_FILTERING_SUSPENSION_TIME, TimeUnit.HOURS);
     }
 }

--- a/src/main/java/com/mindmate/mindmate_server/global/config/RedisConfig.java
+++ b/src/main/java/com/mindmate/mindmate_server/global/config/RedisConfig.java
@@ -1,13 +1,17 @@
 package com.mindmate.mindmate_server.global.config;
 
 import com.mindmate.mindmate_server.chat.util.ChatMessageListener;
+import com.mindmate.mindmate_server.global.util.SuspensionExpirationListener;
+import com.mindmate.mindmate_server.user.service.UserService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.listener.PatternTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
@@ -30,7 +34,19 @@ public class RedisConfig {
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
         RedisStandaloneConfiguration redisConfig = new RedisStandaloneConfiguration(redisHost, redisPort);
-        return new LettuceConnectionFactory(redisConfig);
+        LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(redisConfig);
+
+        // 연결 팩토리 반환 전에 Redis 설정을 적용한다?
+        connectionFactory.afterPropertiesSet();
+
+        // 연결 후 keyspace 알림 설정 적용 -> 키 만료 이벤트 알림 활성화
+        StringRedisTemplate template = new StringRedisTemplate(connectionFactory);
+        template.execute((RedisCallback<Object>) connection -> {
+            connection.setConfig("notify-keyspace-events", "Ex");
+            return null;
+        }) ;
+
+        return connectionFactory;
     }
 
     /**
@@ -64,13 +80,25 @@ public class RedisConfig {
     @Bean
     public RedisMessageListenerContainer redisMessageListenerContainer(
             RedisConnectionFactory connectionFactory,
-            ChatMessageListener chatMessageListener) {
+            ChatMessageListener chatMessageListener,
+            SuspensionExpirationListener suspensionExpirationListener) {
         RedisMessageListenerContainer container = new RedisMessageListenerContainer();
         container.setConnectionFactory(connectionFactory);
 
         container.addMessageListener(chatMessageListener, new PatternTopic("chat:room:*")); // 채팅방 관련 이벤트 구독
         container.addMessageListener(chatMessageListener, new PatternTopic("user:status:*")); // 사용자 상태 관련 이벤트 구독
+
+        // 키 만료 이벤트 구독 설정 -> 키 만료됨에 따라 자동적으로 unsuspension 용도
+        container.addMessageListener(suspensionExpirationListener, new PatternTopic("__keyevent@*__:expired"));;
         return container;
+    }
+
+    /**
+     * 정지 만료 이벤트 리스너 등록
+     */
+    @Bean
+    public SuspensionExpirationListener suspensionExpirationListener(UserService userService) {
+        return new SuspensionExpirationListener(userService);
     }
 
 

--- a/src/main/java/com/mindmate/mindmate_server/global/config/WebConfig.java
+++ b/src/main/java/com/mindmate/mindmate_server/global/config/WebConfig.java
@@ -1,0 +1,13 @@
+package com.mindmate.mindmate_server.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class WebConfig {
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/mindmate/mindmate_server/global/exception/UserErrorCode.java
+++ b/src/main/java/com/mindmate/mindmate_server/global/exception/UserErrorCode.java
@@ -9,7 +9,9 @@ import org.springframework.http.HttpStatus;
 public enum UserErrorCode implements ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다"),
     DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다"),
-    EMAIL_NOT_VERIFIED(HttpStatus.UNAUTHORIZED, "이메일 인증이 필요합니다");
+    EMAIL_NOT_VERIFIED(HttpStatus.UNAUTHORIZED, "이메일 인증이 필요합니다"),
+    ADMIN_SUSPENSION_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "관리자를 정지할 수 없습니다." ),
+    USER_ALREADY_NOT_SUSPENDED(HttpStatus.BAD_REQUEST, "해당 사용자는 정지되지 않은 상태입니다." );
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/mindmate/mindmate_server/global/util/RedisKeyManager.java
+++ b/src/main/java/com/mindmate/mindmate_server/global/util/RedisKeyManager.java
@@ -28,4 +28,15 @@ public class RedisKeyManager {
     public String getReadStatusKey(Long roomId, Long userId) {
         return "chat:room:" + roomId + ":read:" + userId;
     }
+
+    // 사용자별 채팅방 필터링 횟수 키
+    public String getFilteringCountKey(Long userId, Long roomId) {
+        return "filtering:count:" + userId + ":" + roomId;
+    }
+
+    // 필터링 내용 저장 키? todo: 해당 내용을 따로 db에 저장을 해야할까 아니면 짧게짧게 redis로만 관리할까
+    public String getFilteringContentKey(Long userId, Long roomId) {
+        return "filtering:content:" + userId + ":" + roomId;
+    }
+
 }

--- a/src/main/java/com/mindmate/mindmate_server/global/util/RedisKeyManager.java
+++ b/src/main/java/com/mindmate/mindmate_server/global/util/RedisKeyManager.java
@@ -39,4 +39,9 @@ public class RedisKeyManager {
         return "filtering:content:" + userId + ":" + roomId;
     }
 
+    // 사용자 suspension 정보 관리
+    public String getUserSuspensionKey(Long userId) {
+        return "user:suspension:" + userId;
+    }
+
 }

--- a/src/main/java/com/mindmate/mindmate_server/global/util/RedisKeyManager.java
+++ b/src/main/java/com/mindmate/mindmate_server/global/util/RedisKeyManager.java
@@ -30,7 +30,7 @@ public class RedisKeyManager {
     }
 
     // 사용자별 채팅방 필터링 횟수 키
-    public String getFilteringCountKey(Long userId, Long roomId) {
+    public String getFilteringCountKey(Long userId, Object roomId) {
         return "filtering:count:" + userId + ":" + roomId;
     }
 

--- a/src/main/java/com/mindmate/mindmate_server/global/util/SlackNotifier.java
+++ b/src/main/java/com/mindmate/mindmate_server/global/util/SlackNotifier.java
@@ -1,0 +1,62 @@
+package com.mindmate.mindmate_server.global.util;
+
+import com.mindmate.mindmate_server.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SlackNotifier {
+    @Value("${slack.webhook.url}")
+    private String webhookUrl;
+
+    private final RestTemplate restTemplate;
+
+    public void sendSuspensionAlert(User user, String reason, Duration duration) {
+        try {
+            Map<String, Object> payload = new HashMap<>();
+
+            String message = String.format(
+                    ":warning: *사용자 정지 알림*\n" +
+                            "> 사용자: %s (ID: %d)\n" +
+                            "> 이메일: %s\n" +
+                            "> 정지 사유: %s\n" +
+                            "> 정지 기간: %s\n" +
+                            "> 정지 시작 시간: %s\n" +
+                            "> 정지 해제 예정: %s",
+                    user.getProfile().getNickname(),
+                    user.getId(),
+                    user.getEmail(),
+                    reason,
+                    formatDuration(duration),
+                    LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")),
+                    user.getSuspensionEndTime().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
+            );
+
+            payload.put("text", message);
+            restTemplate.postForEntity(webhookUrl, payload, String.class);
+            log.info("Slack 정지 알림 전송 완료: userId={}", user.getId());
+        } catch (Exception e) {
+            log.error("Slack 알림 전송 실패: {}", e.getMessage(), e);
+        }
+    }
+
+    private String formatDuration(Duration duration) {
+        if (duration.toDays() > 0) {
+            return duration.toDays() + "일";
+        } else {
+            return duration.toHours() + "시간";
+        }
+    }
+
+}

--- a/src/main/java/com/mindmate/mindmate_server/global/util/SuspensionExpirationListener.java
+++ b/src/main/java/com/mindmate/mindmate_server/global/util/SuspensionExpirationListener.java
@@ -1,0 +1,41 @@
+package com.mindmate.mindmate_server.global.util;
+
+import com.mindmate.mindmate_server.user.domain.RoleType;
+import com.mindmate.mindmate_server.user.domain.User;
+import com.mindmate.mindmate_server.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SuspensionExpirationListener implements MessageListener {
+    private final UserService userService;
+
+    /**
+     * 키 만료 이벤트 수신하여 해당 사용자의 정지 해제
+     */
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        String expiredKey = new String(message.getBody());
+
+        if (expiredKey.startsWith("user:suspension:")) {
+            try {
+                String userId = expiredKey.substring("user:suspension:".length());
+                Long userIdLong = Long.parseLong(userId);
+
+                User user = userService.findUserById(userIdLong);
+                if (user.getCurrentRole() == RoleType.ROLE_SUSPENDED) {
+                    user.unsuspend();
+                    userService.save(user);
+                    log.info("User {} unsuspended successfully", userIdLong);
+                }
+            } catch (Exception e) {
+                log.error("Error processing suspension expiration: {}", e.getMessage(), e);
+            }
+        }
+    }
+}

--- a/src/main/java/com/mindmate/mindmate_server/report/controller/AdminReportController.java
+++ b/src/main/java/com/mindmate/mindmate_server/report/controller/AdminReportController.java
@@ -4,8 +4,6 @@ import com.mindmate.mindmate_server.report.domain.ReportReason;
 import com.mindmate.mindmate_server.report.domain.ReportTarget;
 import com.mindmate.mindmate_server.report.dto.ReportDetailResponse;
 import com.mindmate.mindmate_server.report.dto.ReportStatisticsResponse;
-import com.mindmate.mindmate_server.report.dto.SuspensionRequest;
-import com.mindmate.mindmate_server.report.dto.UnsuspendRequest;
 import com.mindmate.mindmate_server.report.service.AdminReportService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -44,27 +42,6 @@ public class AdminReportController {
         return ResponseEntity.ok(adminReportService.getReportDetail(reportId));
     }
 
-    /**
-     * 사용자 수동 정지 -> count, suspensionDate 설정
-     */
-    @PostMapping("/users/{userId}/suspend")
-    public ResponseEntity<Void> suspendUser(
-            @PathVariable Long userId,
-            @RequestBody SuspensionRequest request) {
-        adminReportService.suspendUser(userId, request.getReportCount(), request.getDuration());
-        return ResponseEntity.noContent().build();
-    }
-
-    /**
-     * 사용자 정지 해제 -> count 설정 가능 / suspensionDate은 null로 처리
-     */
-    @PostMapping("/users/{userId}/unsuspend")
-    public ResponseEntity<Void> unsuspendUser(
-            @PathVariable Long userId,
-            @RequestBody UnsuspendRequest request) {
-        adminReportService.unsuspendUser(userId, request);
-        return ResponseEntity.noContent().build();
-    }
 
     /**
      * 신고 통계

--- a/src/main/java/com/mindmate/mindmate_server/report/dto/SuspensionRequest.java
+++ b/src/main/java/com/mindmate/mindmate_server/report/dto/SuspensionRequest.java
@@ -10,6 +10,7 @@ import java.time.Duration;
 public class SuspensionRequest {
     private int reportCount;
     private int durationDays;
+    private String reason;
 
     public Duration getDuration() {
         return Duration.ofDays(durationDays);

--- a/src/main/java/com/mindmate/mindmate_server/report/service/AdminReportService.java
+++ b/src/main/java/com/mindmate/mindmate_server/report/service/AdminReportService.java
@@ -4,20 +4,14 @@ import com.mindmate.mindmate_server.report.domain.ReportReason;
 import com.mindmate.mindmate_server.report.domain.ReportTarget;
 import com.mindmate.mindmate_server.report.dto.ReportDetailResponse;
 import com.mindmate.mindmate_server.report.dto.ReportStatisticsResponse;
-import com.mindmate.mindmate_server.report.dto.UnsuspendRequest;
 import org.springframework.data.domain.Page;
 
-import java.time.Duration;
 import java.time.LocalDate;
 
 public interface AdminReportService {
     Page<ReportDetailResponse> getReports(int page, int size, ReportTarget target, ReportReason reason);
 
     ReportDetailResponse getReportDetail(Long reportId);
-
-    void suspendUser(Long userId, int reportCount, Duration duration);
-
-    void unsuspendUser(Long userId, UnsuspendRequest request);
 
     ReportStatisticsResponse getStatistics(LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/com/mindmate/mindmate_server/report/service/AdminReportServiceImpl.java
+++ b/src/main/java/com/mindmate/mindmate_server/report/service/AdminReportServiceImpl.java
@@ -5,19 +5,14 @@ import com.mindmate.mindmate_server.report.domain.ReportReason;
 import com.mindmate.mindmate_server.report.domain.ReportTarget;
 import com.mindmate.mindmate_server.report.dto.ReportDetailResponse;
 import com.mindmate.mindmate_server.report.dto.ReportStatisticsResponse;
-import com.mindmate.mindmate_server.report.dto.UnsuspendRequest;
 import com.mindmate.mindmate_server.report.repository.ReportRepository;
-import com.mindmate.mindmate_server.user.domain.User;
-import com.mindmate.mindmate_server.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Map;
@@ -26,7 +21,6 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class AdminReportServiceImpl implements AdminReportService {
     private final ReportRepository reportRepository;
-    private final UserService userService;
     private final ReportService reportService;
 
     @Override
@@ -40,24 +34,6 @@ public class AdminReportServiceImpl implements AdminReportService {
     @Override
     public ReportDetailResponse getReportDetail(Long reportId) {
         return ReportDetailResponse.from(reportService.findReportById(reportId));
-    }
-
-    @Override
-    @Transactional
-    public void suspendUser(Long userId, int reportCount, Duration duration) {
-        User user = userService.findUserById(userId);
-        user.setReportCount(reportCount);
-        user.suspend(duration);
-        userService.save(user);
-    }
-
-    @Override
-    @Transactional
-    public void unsuspendUser(Long userId, UnsuspendRequest request) {
-        User user = userService.findUserById(userId);
-        user.setReportCount(request.getReportCount());
-        user.unsuspend();
-        userService.save(user);
     }
 
     @Override

--- a/src/main/java/com/mindmate/mindmate_server/report/util/SuspensionScheduler.java
+++ b/src/main/java/com/mindmate/mindmate_server/report/util/SuspensionScheduler.java
@@ -15,8 +15,8 @@ import java.util.List;
 public class SuspensionScheduler {
     private final UserService userService;
 
-    // todo: unsuspend하는 방식 다른 방식 고려 -> AOP 이용해서 api 호출 시 확인? 너무 비효율적 아닌가
-    @Scheduled(fixedRate = 3600000)
+    // redis 이벤트 누락 시 처리
+    @Scheduled(fixedRate = 21600000)
     public void checkAndUnsuspendUsers() {
         List<User> susendedUsers = userService.findByCurrentRoleAndSuspensionEndTimeBefore(
                 RoleType.ROLE_SUSPENDED, LocalDateTime.now()

--- a/src/main/java/com/mindmate/mindmate_server/user/controller/AdminUserSuspensionController.java
+++ b/src/main/java/com/mindmate/mindmate_server/user/controller/AdminUserSuspensionController.java
@@ -1,0 +1,48 @@
+package com.mindmate.mindmate_server.user.controller;
+
+import com.mindmate.mindmate_server.report.dto.SuspensionRequest;
+import com.mindmate.mindmate_server.report.dto.UnsuspendRequest;
+import com.mindmate.mindmate_server.user.dto.SuspendedUserDTO;
+import com.mindmate.mindmate_server.user.service.AdminUserSuspensionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/users")
+public class AdminUserSuspensionController {
+    private final AdminUserSuspensionService suspensionService;
+
+    /**
+     * 현재 정지된 모든 사용자 조회
+     */
+    @GetMapping("/suspended")
+    public ResponseEntity<List<SuspendedUserDTO>> getSuspendedUsers() {
+        return ResponseEntity.ok(suspensionService.getAllSuspendedUsers());
+    }
+
+    /**
+     * 사용자 정지 처리
+     */
+    @PostMapping("/{userId}/suspend")
+    public ResponseEntity<Void> suspendUser(
+            @PathVariable Long userId,
+            @RequestBody SuspensionRequest request) {
+        suspensionService.suspendUser(userId, request.getReportCount(), request.getDuration(), request.getReason());
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 사용자 정지 해제
+     */
+    @PostMapping("/{userId}/unsuspend")
+    public ResponseEntity<Void> unsuspendUser(
+            @PathVariable Long userId,
+            @RequestBody UnsuspendRequest request) {
+        suspensionService.unsuspendUser(userId, request);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/mindmate/mindmate_server/user/dto/SuspendedUserDTO.java
+++ b/src/main/java/com/mindmate/mindmate_server/user/dto/SuspendedUserDTO.java
@@ -1,0 +1,21 @@
+package com.mindmate.mindmate_server.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class SuspendedUserDTO {
+    private Long userId;
+    private String email;
+    private String nickname;
+    private int reportCount;
+    private LocalDateTime suspensionEndTime;
+    private String suspensionReason;
+}

--- a/src/main/java/com/mindmate/mindmate_server/user/service/AdminUserSuspensionService.java
+++ b/src/main/java/com/mindmate/mindmate_server/user/service/AdminUserSuspensionService.java
@@ -1,0 +1,118 @@
+package com.mindmate.mindmate_server.user.service;
+
+import com.mindmate.mindmate_server.global.exception.CustomException;
+import com.mindmate.mindmate_server.global.exception.UserErrorCode;
+import com.mindmate.mindmate_server.global.util.RedisKeyManager;
+import com.mindmate.mindmate_server.global.util.SlackNotifier;
+import com.mindmate.mindmate_server.report.dto.UnsuspendRequest;
+import com.mindmate.mindmate_server.user.domain.RoleType;
+import com.mindmate.mindmate_server.user.domain.User;
+import com.mindmate.mindmate_server.user.dto.SuspendedUserDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AdminUserSuspensionService {
+    private final UserService userService;
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final RedisKeyManager redisKeyManager;
+    private final SlackNotifier slackNotifier;
+
+    /**
+     * 사용자 정지 처리
+     */
+    @Transactional
+    public void suspendUser(Long userId, int reportCount, Duration duration, String reason) {
+        User user = userService.findUserById(userId);
+
+        if (user.getCurrentRole().equals(RoleType.ROLE_ADMIN)) {
+            throw new CustomException(UserErrorCode.ADMIN_SUSPENSION_NOT_ALLOWED);
+        }
+
+        if (reportCount >= 0) {
+            user.setReportCount(reportCount);
+        }
+
+        user.suspend(duration);
+        userService.save(user);
+
+        String suspensionKey = redisKeyManager.getUserSuspensionKey(userId);
+        redisTemplate.opsForValue().set(suspensionKey, "suspended");
+
+        if (duration.toDays() > 0) {
+            redisTemplate.expire(suspensionKey, duration.toDays(), TimeUnit.DAYS);
+        } else {
+            redisTemplate.expire(suspensionKey, duration.toHours(), TimeUnit.HOURS);
+        }
+
+        slackNotifier.sendSuspensionAlert(user, reason, duration);
+    }
+
+    /**
+     * 사용자 정지 해제 처리
+     */
+    @Transactional
+    public void unsuspendUser(Long userId, UnsuspendRequest request) {
+        User user = userService.findUserById(userId);
+        Integer reportCount = request.getReportCount();
+
+        if (!user.getCurrentRole().equals(RoleType.ROLE_SUSPENDED)) {
+            throw new CustomException(UserErrorCode.USER_ALREADY_NOT_SUSPENDED);
+        }
+
+        if (reportCount != null) {
+            user.setReportCount(reportCount);
+        }
+
+        user.unsuspend();
+        userService.save(user);
+
+        String suspensionKey = redisKeyManager.getUserSuspensionKey(userId);
+        redisTemplate.delete(suspensionKey);
+    }
+
+    /**
+     * 정지된 모든 사용자 조회
+     */
+    public List<SuspendedUserDTO> getAllSuspendedUsers() {
+        Set<String> suspensionKeys = redisTemplate.keys("user:suspension:*");
+        List<SuspendedUserDTO> suspendedUsers = new ArrayList<>();
+
+        for (String key : suspensionKeys) {
+            try {
+                String userId = key.substring("user:suspension:".length());
+                User user = userService.findUserById(Long.parseLong(userId));
+
+                String suspensionReason = "Unknown";
+                Object reasonValue = redisTemplate.opsForValue().get(key);
+                if (reasonValue != null) {
+                    suspensionReason = reasonValue.toString();
+                }
+
+                SuspendedUserDTO dto = SuspendedUserDTO.builder()
+                        .userId(user.getId())
+                        .email(user.getEmail())
+                        .nickname(user.getProfile().getNickname())
+                        .reportCount(user.getReportCount())
+                        .suspensionEndTime(user.getSuspensionEndTime())
+                        .suspensionReason(suspensionReason)
+                        .build();
+                suspendedUsers.add(dto);
+            } catch (Exception e) {
+                log.error("Error processing suspension key {}: {}", key, e.getMessage());
+            }
+        }
+        return suspendedUsers;
+    }
+}

--- a/src/test/java/com/mindmate/mindmate_server/report/service/AdminReportServiceImplTest.java
+++ b/src/test/java/com/mindmate/mindmate_server/report/service/AdminReportServiceImplTest.java
@@ -133,40 +133,40 @@ class AdminReportServiceImplTest {
     @Nested
     @DisplayName("사용자 정지 테스트")
     class SuspendUserTest {
-        @Test
-        @DisplayName("사용자 정지 성공")
-        void suspendUser_Success() {
-            // given
-            int reportCount = 5;
-            Duration duration = Duration.ofDays(3);
-
-            // when
-            adminReportService.suspendUser(userId, reportCount, duration);
-
-            // then
-            verify(mockUser).setReportCount(reportCount);
-            verify(mockUser).suspend(duration);
-            verify(userService).save(mockUser);
-        }
+//        @Test
+//        @DisplayName("사용자 정지 성공")
+//        void suspendUser_Success() {
+//            // given
+//            int reportCount = 5;
+//            Duration duration = Duration.ofDays(3);
+//
+//            // when
+//            adminReportService.suspendUser(userId, reportCount, duration);
+//
+//            // then
+//            verify(mockUser).setReportCount(reportCount);
+//            verify(mockUser).suspend(duration);
+//            verify(userService).save(mockUser);
+//        }
     }
 
     @Nested
     @DisplayName("사용자 정지 해제 테스트")
     class UnsuspendUserTest {
-        @Test
-        @DisplayName("사용자 정지 해제 성공")
-        void unsuspendUser_Success() {
-            // given
-            UnsuspendRequest request = UnsuspendRequest.builder().reportCount(0).build();
-
-            // when
-            adminReportService.unsuspendUser(userId, request);
-
-            // then
-            verify(mockUser).setReportCount(0);
-            verify(mockUser).unsuspend();
-            verify(userService).save(mockUser);
-        }
+//        @Test
+//        @DisplayName("사용자 정지 해제 성공")
+//        void unsuspendUser_Success() {
+//            // given
+//            UnsuspendRequest request = UnsuspendRequest.builder().reportCount(0).build();
+//
+//            // when
+//            adminReportService.unsuspendUser(userId, request);
+//
+//            // then
+//            verify(mockUser).setReportCount(0);
+//            verify(mockUser).unsuspend();
+//            verify(userService).save(mockUser);
+//        }
     }
 
     @Nested


### PR DESCRIPTION
## 🛰️ Issue Number
#70 

## 🪐 작업 내용
1. 채팅 필터링 컨슈머 추가
2. 사용자 각 채팅방에서 필터링 횟수 계산 + 임계값에 따라 정지
3. 슬랙 알림 추가
4. 기존 중복 코드 통일