### PR TITLE
[Feat#80] 채팅, 매거진에서 이모티콘 사용

### DIFF
--- a/src/main/java/com/mindmate/mindmate_server/chat/controller/WebSocketChatController.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/controller/WebSocketChatController.java
@@ -2,6 +2,9 @@ package com.mindmate.mindmate_server.chat.controller;
 
 import com.mindmate.mindmate_server.chat.dto.*;
 import com.mindmate.mindmate_server.chat.service.*;
+import com.mindmate.mindmate_server.emoticon.dto.EmoticonMessageRequest;
+import com.mindmate.mindmate_server.emoticon.dto.EmoticonMessageResponse;
+import com.mindmate.mindmate_server.emoticon.service.EmoticonService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.MessageMapping;
@@ -22,6 +25,8 @@ public class WebSocketChatController {
     private final ChatPresenceService chatPresenceService;
     private final MessageReactionService messageReactionService;
     private final CustomFormService customFormService;
+    private final EmoticonService emoticonService;
+
 
     private final ChatEventPublisher eventPublisher;
 
@@ -124,5 +129,16 @@ public class WebSocketChatController {
         Long userId = Long.parseLong(principal.getName());
         CustomFormResponse response = customFormService.respondToCustomForm(request.getFormId(), userId, request);
         eventPublisher.publishChatRoomEvent(request.getChatRoomId(), ChatEventType.CUSTOM_FORM_RESPONSE, response);
+    }
+
+    /**
+     * 이모티콘 전송
+     */
+    @MessageMapping("/chat.emoticon")
+    public void sendEmoticon(@Payload EmoticonMessageRequest request, Principal principal) {
+        Long userId = Long.parseLong(principal.getName());
+
+        EmoticonMessageResponse response = emoticonService.sendEmoticonMessage(userId, request);
+        eventPublisher.publishChatRoomEvent(request.getRoomId(), ChatEventType.EMOTICON, response);
     }
 }

--- a/src/main/java/com/mindmate/mindmate_server/chat/domain/ChatMessage.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/domain/ChatMessage.java
@@ -1,5 +1,6 @@
 package com.mindmate.mindmate_server.chat.domain;
 
+import com.mindmate.mindmate_server.emoticon.domain.Emoticon;
 import com.mindmate.mindmate_server.global.entity.BaseTimeEntity;
 import com.mindmate.mindmate_server.user.domain.User;
 import jakarta.persistence.*;
@@ -36,6 +37,10 @@ public class ChatMessage extends BaseTimeEntity {
     @JoinColumn(name = "custom_form_id")
     private CustomForm customForm;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "emoticon_id")
+    private Emoticon emoticon;
+
     @Column(columnDefinition = "TEXT")
     private String content;
     
@@ -65,6 +70,14 @@ public class ChatMessage extends BaseTimeEntity {
 
     public void setCustomForm(CustomForm customForm) {
         this.customForm = customForm;
+    }
+
+    public boolean isEmoticon() {
+        return this.type == MessageType.EMOTICON;
+    }
+
+    public void setEmoticon(Emoticon emoticon) {
+        this.emoticon = emoticon;
     }
 
     public void updateEncryptedContent(String encryptedContent) {

--- a/src/main/java/com/mindmate/mindmate_server/chat/dto/ChatEventType.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/dto/ChatEventType.java
@@ -12,5 +12,6 @@ public enum ChatEventType {
     CUSTOM_FORM_RESPONSE,
     CONTENT_FILTERED,
     USER_STATUS,
-    TOAST_BOX
+    TOAST_BOX,
+    EMOTICON
 }

--- a/src/main/java/com/mindmate/mindmate_server/chat/dto/ChatMessageEvent.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/dto/ChatMessageEvent.java
@@ -28,6 +28,8 @@ public class ChatMessageEvent {
     private boolean encrypted;
     private String plainContent;
 
+    // todo: 이모티콘 관려 데이터? -> 활용을 안하더라도 이벤트 발행하는거니까..음
+
     public void setId(Long id) {
         this.messageId = id;
     }

--- a/src/main/java/com/mindmate/mindmate_server/chat/dto/ChatMessageResponse.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/dto/ChatMessageResponse.java
@@ -34,6 +34,10 @@ public class ChatMessageResponse {
 
     private CustomFormResponse customForm;
 
+    private Long emoticonId;
+    private String emoticonUrl;
+    private String emoticonName;
+
     public static ChatMessageResponse from(ChatMessage message, Long currentUserId) {
         Map<ReactionType, Integer> reactionCounts = new HashMap<>();
         for (MessageReaction reaction : message.getMessageReactions()) {
@@ -57,6 +61,15 @@ public class ChatMessageResponse {
             customFormResponse = CustomFormResponse.from(message.getCustomForm());
         }
 
+        Long emoticonId = null;
+        String emoticonUrl = null;
+        String emoticonName = null;
+        if (message.getType() == MessageType.EMOTICON && message.getEmoticon() != null) {
+            emoticonId = message.getEmoticon().getId();
+            emoticonUrl = message.getEmoticon().getImageUrl();
+            emoticonName = message.getEmoticon().getName();
+        }
+
         return ChatMessageResponse.builder()
                 .id(message.getId())
 //                .roomId(message.getChatRoom().getId())
@@ -69,6 +82,9 @@ public class ChatMessageResponse {
                 .userReaction(userReaction)
                 .error(false)
                 .customForm(customFormResponse)
+                .emoticonId(emoticonId)
+                .emoticonUrl(emoticonUrl)
+                .emoticonName(emoticonName)
                 .build();
     }
 

--- a/src/main/java/com/mindmate/mindmate_server/chat/service/CustomFormServiceImpl.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/service/CustomFormServiceImpl.java
@@ -31,6 +31,7 @@ public class CustomFormServiceImpl implements CustomFormService {
     private final ChatPresenceService chatPresenceService;
 
 
+    // todo: chatservice에서 처리?
     @Override
     @Transactional
     public CustomFormResponse createCustomForm(Long userId, CustomFormRequest request) {

--- a/src/main/java/com/mindmate/mindmate_server/chat/service/ToastBoxConsumer.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/service/ToastBoxConsumer.java
@@ -1,5 +1,6 @@
 package com.mindmate.mindmate_server.chat.service;
 
+import com.mindmate.mindmate_server.chat.domain.MessageType;
 import com.mindmate.mindmate_server.chat.domain.ToastBoxKeyword;
 import com.mindmate.mindmate_server.chat.dto.ChatEventType;
 import com.mindmate.mindmate_server.chat.dto.ChatMessageEvent;
@@ -28,7 +29,7 @@ public class ToastBoxConsumer {
     public void processToastBox(ConsumerRecord<String, ChatMessageEvent> record) {
         ChatMessageEvent event = record.value();
 
-        if (event.isFiltered() || event.getMessageId() == null) {
+        if (event.isFiltered() || event.getMessageId() == null || event.getType() == MessageType.EMOTICON) {
             return;
         }
 

--- a/src/main/java/com/mindmate/mindmate_server/chat/util/WebSocketDestinationResolver.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/util/WebSocketDestinationResolver.java
@@ -19,6 +19,8 @@ public class WebSocketDestinationResolver {
                 case CUSTOM_FORM:
                 case CUSTOM_FORM_RESPONSE:
                     return "/topic/chat.room." + roomId + ".customform";
+                case EMOTICON:
+                    return "/topic/chat.room." + roomId + ".emoticon";  // 추가
                 default:
                     return "/topic/chat.room." + roomId;
             }

--- a/src/main/java/com/mindmate/mindmate_server/emoticon/dto/EmoticonMessageRequest.java
+++ b/src/main/java/com/mindmate/mindmate_server/emoticon/dto/EmoticonMessageRequest.java
@@ -1,0 +1,15 @@
+package com.mindmate.mindmate_server.emoticon.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class EmoticonMessageRequest {
+    private Long roomId;
+    private Long emoticonId;
+}

--- a/src/main/java/com/mindmate/mindmate_server/emoticon/dto/EmoticonMessageResponse.java
+++ b/src/main/java/com/mindmate/mindmate_server/emoticon/dto/EmoticonMessageResponse.java
@@ -1,0 +1,36 @@
+package com.mindmate.mindmate_server.emoticon.dto;
+
+import com.mindmate.mindmate_server.chat.domain.ChatMessage;
+import com.mindmate.mindmate_server.chat.domain.MessageType;
+import com.mindmate.mindmate_server.emoticon.domain.Emoticon;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class EmoticonMessageResponse {
+    private Long messageId;
+    private Long roomId;
+    private Long senderId;
+    private String senderName;
+    private Long emoticonId;
+    private String emoticonUrl;
+    private String emoticonName;
+    private LocalDateTime timestamp;
+    private MessageType type = MessageType.EMOTICON;
+
+    public static EmoticonMessageResponse from(ChatMessage message, Emoticon emoticon, String senderName) {
+        return EmoticonMessageResponse.builder()
+                .messageId(message.getId())
+                .roomId(message.getChatRoom().getId())
+                .senderId(message.getSender().getId())
+                .senderName(senderName)
+                .emoticonId(emoticon.getId())
+                .emoticonUrl(emoticon.getImageUrl())
+                .emoticonName(emoticon.getName())
+                .timestamp(message.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/mindmate/mindmate_server/emoticon/service/EmoticonService.java
+++ b/src/main/java/com/mindmate/mindmate_server/emoticon/service/EmoticonService.java
@@ -1,10 +1,7 @@
 package com.mindmate.mindmate_server.emoticon.service;
 
 import com.mindmate.mindmate_server.emoticon.domain.Emoticon;
-import com.mindmate.mindmate_server.emoticon.dto.EmoticonDetailResponse;
-import com.mindmate.mindmate_server.emoticon.dto.EmoticonResponse;
-import com.mindmate.mindmate_server.emoticon.dto.EmoticonUploadRequest;
-import com.mindmate.mindmate_server.emoticon.dto.UserEmoticonResponse;
+import com.mindmate.mindmate_server.emoticon.dto.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
@@ -30,4 +27,6 @@ public interface EmoticonService {
     EmoticonResponse purchaseEmoticon(Long userId, Long emoticonId);
 
     boolean isEmoticonOwnedByUser(Long userId, Long emoticonId);
+
+    EmoticonMessageResponse sendEmoticonMessage(Long userId, EmoticonMessageRequest request);
 }

--- a/src/main/java/com/mindmate/mindmate_server/global/config/SecurityConfig.java
+++ b/src/main/java/com/mindmate/mindmate_server/global/config/SecurityConfig.java
@@ -68,6 +68,8 @@ public class SecurityConfig {
                         .accessDeniedHandler(customAccessDeniedHandler())) // 권한 부족시
                 .authorizeHttpRequests(auth -> auth
                     .requestMatchers(
+                            "/emoticons/**",
+                            "/images/**",
                             "/ws/**",
                             "/api/auth/register",
                             "/api/auth/login",

--- a/src/main/java/com/mindmate/mindmate_server/global/config/WebMvcConfig.java
+++ b/src/main/java/com/mindmate/mindmate_server/global/config/WebMvcConfig.java
@@ -16,9 +16,12 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
         registry.addResourceHandler("/images/**")
-                .addResourceLocations("file://" + imageDir);
+                .addResourceLocations("file:" + imageDir);
 
+
+//        registry.addResourceHandler("/emoticons/**")
+//                .addResourceLocations("file://" + emoticonDir);
         registry.addResourceHandler("/emoticons/**")
-                .addResourceLocations("file://" + emoticonDir);
+                .addResourceLocations("file:" + emoticonDir);
     }
 }

--- a/src/main/java/com/mindmate/mindmate_server/global/exception/EmoticonErrorCode.java
+++ b/src/main/java/com/mindmate/mindmate_server/global/exception/EmoticonErrorCode.java
@@ -12,7 +12,9 @@ public enum EmoticonErrorCode implements ErrorCode {
     INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 파일 형식입니다."),
     FILE_TOO_LARGE(HttpStatus.PAYLOAD_TOO_LARGE, "파일 크기가 너무 큽니다."),
     ALREADY_PURCHASED(HttpStatus.BAD_REQUEST, "이미 구매한 이모티콘입니다."),
-    INSUFFICIENT_POINTS(HttpStatus.BAD_REQUEST, "포인트가 부족합니다.");
+    INSUFFICIENT_POINTS(HttpStatus.BAD_REQUEST, "포인트가 부족합니다."),
+    EMOTICON_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "이모티콘에 접근 권한이 없습니다" ), 
+    EMOTICON_SEND_FAILED(HttpStatus.BAD_REQUEST, "이모티콘 전송에 실패했습니다");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/mindmate/mindmate_server/magazine/domain/Magazine.java
+++ b/src/main/java/com/mindmate/mindmate_server/magazine/domain/Magazine.java
@@ -24,15 +24,13 @@ public class Magazine extends BaseTimeEntity {
     @Column(nullable = false)
     private String title;
 
-    @Column(nullable = false, columnDefinition = "TEXT")
-    private String content;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "author_id", nullable = false)
     private User author;
 
     @OneToMany(mappedBy = "magazine", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<MagazineImage> images = new ArrayList<>();
+    @OrderBy("contentOrder ASC")
+    private List<MagazineContent> contents = new ArrayList<>();
 
     @OneToMany(mappedBy = "magazine", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MagazineLike> likes = new ArrayList<>();
@@ -47,15 +45,13 @@ public class Magazine extends BaseTimeEntity {
     private MatchingCategory category;
 
     @Builder
-    public Magazine(String title, String content, User author) {
+    public Magazine(String title, User author) {
         this.title = title;
-        this.content = content;
         this.author = author;
     }
 
-    public void update(String title, String content, MatchingCategory category) {
+    public void update(String title, MatchingCategory category) {
         this.title = title;
-        this.content = content;
         this.category = category;
         this.magazineStatus = MagazineStatus.PENDING;
     }
@@ -76,12 +72,16 @@ public class Magazine extends BaseTimeEntity {
         this.likeCount = Math.max(0, this.likeCount - 1);
     }
 
-    public void addImage(MagazineImage image) {
-        this.images.add(image);
-        image.setMagazine(this);
+    public void addContent(MagazineContent content) {
+        this.contents.add(content);
+        content.setMagazine(this);
     }
 
-    public void removeImage(MagazineImage image) {
-        this.images.remove(image);
+    public void removeContent(MagazineContent content) {
+        this.contents.remove(content);
+    }
+
+    public void clearContents() {
+        this.contents.clear();
     }
 }

--- a/src/main/java/com/mindmate/mindmate_server/magazine/domain/MagazineContent.java
+++ b/src/main/java/com/mindmate/mindmate_server/magazine/domain/MagazineContent.java
@@ -1,0 +1,54 @@
+package com.mindmate.mindmate_server.magazine.domain;
+
+import com.mindmate.mindmate_server.emoticon.domain.Emoticon;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "magazine_contents")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MagazineContent {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "magazine_id", nullable = false)
+    private Magazine magazine;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MagazineContentType type;
+
+    @Column(columnDefinition = "TEXT")
+    private String text;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "image_id")
+    private MagazineImage image;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "emoticon_id")
+    private Emoticon emoticon;
+
+    @Column(nullable = false)
+    private int contentOrder;
+
+    @Builder
+    public MagazineContent(Magazine magazine, MagazineContentType type, String text, MagazineImage image, Emoticon emoticon, int contentOrder) {
+        this.magazine = magazine;
+        this.type = type;
+        this.text = text;
+        this.image = image;
+        this.emoticon = emoticon;
+        this.contentOrder = contentOrder;
+    }
+
+    public void setMagazine(Magazine magazine) {
+        this.magazine = magazine;
+    }
+}

--- a/src/main/java/com/mindmate/mindmate_server/magazine/domain/MagazineContentType.java
+++ b/src/main/java/com/mindmate/mindmate_server/magazine/domain/MagazineContentType.java
@@ -1,0 +1,7 @@
+package com.mindmate.mindmate_server.magazine.domain;
+
+public enum MagazineContentType {
+    TEXT,
+    IMAGE,
+    EMOTICON
+}

--- a/src/main/java/com/mindmate/mindmate_server/magazine/domain/MagazineImage.java
+++ b/src/main/java/com/mindmate/mindmate_server/magazine/domain/MagazineImage.java
@@ -31,21 +31,13 @@ public class MagazineImage extends BaseTimeEntity {
     @Column(nullable = false)
     private long fileSize;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "magazine_id")
-    private Magazine magazine;
-
     @Builder
-    public MagazineImage(String originalName, String storedName, String imageUrl, String contentType, long fileSize, Magazine magazine) {
+    public MagazineImage(String originalName, String storedName, String imageUrl, String contentType, long fileSize) {
         this.originalName = originalName;
         this.storedName = storedName;
         this.imageUrl = imageUrl;
         this.contentType = contentType;
         this.fileSize = fileSize;
-        this.magazine = magazine;
     }
 
-    public void setMagazine(Magazine magazine) {
-        this.magazine = magazine;
-    }
 }

--- a/src/main/java/com/mindmate/mindmate_server/magazine/dto/MagazineContentDTO.java
+++ b/src/main/java/com/mindmate/mindmate_server/magazine/dto/MagazineContentDTO.java
@@ -1,0 +1,18 @@
+package com.mindmate.mindmate_server.magazine.dto;
+
+import com.mindmate.mindmate_server.magazine.domain.MagazineContentType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MagazineContentDTO {
+    private MagazineContentType type;
+    private String text;
+    private Long imageId;
+    private Long emoticonId;
+}

--- a/src/main/java/com/mindmate/mindmate_server/magazine/dto/MagazineContentResponse.java
+++ b/src/main/java/com/mindmate/mindmate_server/magazine/dto/MagazineContentResponse.java
@@ -30,6 +30,7 @@ public class MagazineContentResponse {
                 if (content.getImage() != null) {
                     builder.imageUrl(content.getImage().getImageUrl());
                 }
+                break;
             case EMOTICON:
                 if (content.getEmoticon() != null) {
                     builder.emoticonUrl(content.getEmoticon().getImageUrl());

--- a/src/main/java/com/mindmate/mindmate_server/magazine/dto/MagazineContentResponse.java
+++ b/src/main/java/com/mindmate/mindmate_server/magazine/dto/MagazineContentResponse.java
@@ -1,0 +1,42 @@
+package com.mindmate.mindmate_server.magazine.dto;
+
+import com.mindmate.mindmate_server.magazine.domain.MagazineContent;
+import com.mindmate.mindmate_server.magazine.domain.MagazineContentType;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MagazineContentResponse {
+    private Long id;
+    private MagazineContentType type;
+    private String text;
+    private String imageUrl;
+    private String emoticonUrl;
+    private String emoticonName;
+    private int contentOrder;
+
+    public static MagazineContentResponse from(MagazineContent content) {
+        MagazineContentResponseBuilder builder = MagazineContentResponse.builder()
+                .id(content.getId())
+                .type(content.getType())
+                .contentOrder(content.getContentOrder());
+
+        switch (content.getType()) {
+            case TEXT:
+                builder.text(content.getText());
+                break;
+            case IMAGE:
+                if (content.getImage() != null) {
+                    builder.imageUrl(content.getImage().getImageUrl());
+                }
+            case EMOTICON:
+                if (content.getEmoticon() != null) {
+                    builder.emoticonUrl(content.getEmoticon().getImageUrl());
+                    builder.emoticonName(content.getEmoticon().getName());
+                }
+                break;
+        }
+        return builder.build();
+    }
+}

--- a/src/main/java/com/mindmate/mindmate_server/magazine/dto/MagazineCreateRequest.java
+++ b/src/main/java/com/mindmate/mindmate_server/magazine/dto/MagazineCreateRequest.java
@@ -18,11 +18,9 @@ public class MagazineCreateRequest {
     @NotBlank
     private String title;
 
-    @NotBlank
-    private String content;
-
     @NotNull
     private MatchingCategory category;
 
-    private List<Long> imageIds;
+    @NotNull
+    private List<MagazineContentDTO> contents;
 }

--- a/src/main/java/com/mindmate/mindmate_server/magazine/dto/MagazineDetailResponse.java
+++ b/src/main/java/com/mindmate/mindmate_server/magazine/dto/MagazineDetailResponse.java
@@ -1,5 +1,6 @@
 package com.mindmate.mindmate_server.magazine.dto;
 
+import com.mindmate.mindmate_server.magazine.domain.MagazineStatus;
 import com.mindmate.mindmate_server.matching.domain.MatchingCategory;
 import com.mindmate.mindmate_server.magazine.domain.Magazine;
 import lombok.Builder;
@@ -14,38 +15,36 @@ import java.util.stream.Collectors;
 public class MagazineDetailResponse {
     private Long id;
     private String title;
-    private String content;
-    private MatchingCategory category;
+    private List<MagazineContentResponse> contents;
     private String authorName;
     private Long authorId;
     private int likeCount;
-    private boolean isAuthor;
-    private boolean isLiked;
-    private List<ImageResponse> images;
+    private MagazineStatus status;
+    private MatchingCategory category;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
+    private boolean isAuthor;
+    private boolean isLiked;
+
     public static MagazineDetailResponse from(Magazine magazine, boolean isAuthor, boolean isLiked) {
-        List<ImageResponse> imageResponses = magazine.getImages().stream()
-                .map(image -> ImageResponse.builder()
-                        .id(image.getId())
-                        .imageUrl(image.getImageUrl())
-                        .build())
+        List<MagazineContentResponse> contentResponses = magazine.getContents().stream()
+                .map(MagazineContentResponse::from)
                 .collect(Collectors.toList());
 
         return MagazineDetailResponse.builder()
                 .id(magazine.getId())
                 .title(magazine.getTitle())
-                .content(magazine.getContent())
-                .category(magazine.getCategory())
+                .contents(contentResponses)
                 .authorName(magazine.getAuthor().getProfile().getNickname())
                 .authorId(magazine.getAuthor().getId())
                 .likeCount(magazine.getLikeCount())
-                .isAuthor(isAuthor)
-                .isLiked(isLiked)
-                .images(imageResponses)
+                .status(magazine.getMagazineStatus())
+                .category(magazine.getCategory())
                 .createdAt(magazine.getCreatedAt())
                 .updatedAt(magazine.getModifiedAt())
+                .isAuthor(isAuthor)
+                .isLiked(isLiked)
                 .build();
     }
 }

--- a/src/main/java/com/mindmate/mindmate_server/magazine/dto/MagazineResponse.java
+++ b/src/main/java/com/mindmate/mindmate_server/magazine/dto/MagazineResponse.java
@@ -1,14 +1,13 @@
 package com.mindmate.mindmate_server.magazine.dto;
 
-import com.mindmate.mindmate_server.magazine.domain.MagazineImage;
-import com.mindmate.mindmate_server.matching.domain.MatchingCategory;
 import com.mindmate.mindmate_server.magazine.domain.Magazine;
+import com.mindmate.mindmate_server.magazine.domain.MagazineStatus;
+import com.mindmate.mindmate_server.matching.domain.MatchingCategory;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.awt.*;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -20,32 +19,29 @@ import java.util.stream.Collectors;
 public class MagazineResponse {
     private Long id;
     private String title;
-    private String content;
-    private MatchingCategory category;
+    private List<MagazineContentResponse> contents;
     private String authorName;
     private Long authorId;
     private int likeCount;
-    private List<ImageResponse> images;
+    private MagazineStatus status;
+    private MatchingCategory category;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
     public static MagazineResponse from(Magazine magazine) {
-        List<ImageResponse> imageResponses = magazine.getImages().stream()
-                .map(image -> ImageResponse.builder()
-                        .id(image.getId())
-                        .imageUrl(image.getImageUrl())
-                        .build())
+        List<MagazineContentResponse> contentResponses = magazine.getContents().stream()
+                .map(MagazineContentResponse::from)
                 .collect(Collectors.toList());
 
         return MagazineResponse.builder()
                 .id(magazine.getId())
                 .title(magazine.getTitle())
-                .content(magazine.getContent())
-                .category(magazine.getCategory())
+                .contents(contentResponses)
                 .authorName(magazine.getAuthor().getProfile().getNickname())
                 .authorId(magazine.getAuthor().getId())
                 .likeCount(magazine.getLikeCount())
-                .images(imageResponses)
+                .status(magazine.getMagazineStatus())
+                .category(magazine.getCategory())
                 .createdAt(magazine.getCreatedAt())
                 .updatedAt(magazine.getModifiedAt())
                 .build();

--- a/src/main/java/com/mindmate/mindmate_server/magazine/dto/MagazineUpdateRequest.java
+++ b/src/main/java/com/mindmate/mindmate_server/magazine/dto/MagazineUpdateRequest.java
@@ -14,11 +14,9 @@ public class MagazineUpdateRequest {
     @NotBlank
     private String title;
 
-    @NotBlank
-    private String content;
-
     @NotNull
     private MatchingCategory category;
 
-    private List<Long> imageIds;
+    @NotNull
+    private List<MagazineContentDTO> contents;
 }

--- a/src/main/java/com/mindmate/mindmate_server/magazine/repository/MagazineContentRepository.java
+++ b/src/main/java/com/mindmate/mindmate_server/magazine/repository/MagazineContentRepository.java
@@ -1,0 +1,24 @@
+package com.mindmate.mindmate_server.magazine.repository;
+
+import com.mindmate.mindmate_server.magazine.domain.Magazine;
+import com.mindmate.mindmate_server.magazine.domain.MagazineContent;
+import com.mindmate.mindmate_server.magazine.domain.MagazineContentType;
+import com.mindmate.mindmate_server.magazine.domain.MagazineImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface MagazineContentRepository extends JpaRepository<MagazineContent, Long> {
+//    List<MagazineContent> findByMagazineOrderByContentOrderAsc(Magazine magazine);
+
+    void deleteByMagazine(Magazine magazine);
+
+    Optional<MagazineContent> findByImageAndType(MagazineImage image, MagazineContentType type);
+
+    boolean existsByImage(MagazineImage image);
+
+    List<MagazineContent> findByImage(MagazineImage magazineImage);
+}

--- a/src/main/java/com/mindmate/mindmate_server/magazine/repository/MagazineImageRepository.java
+++ b/src/main/java/com/mindmate/mindmate_server/magazine/repository/MagazineImageRepository.java
@@ -10,5 +10,7 @@ import java.util.List;
 @Repository
 public interface MagazineImageRepository extends JpaRepository<MagazineImage, Long> {
 
-    List<MagazineImage> findByMagazineIsNullAndCreatedAtBefore(LocalDateTime localDateTime);
+//    List<MagazineImage> findByMagazineIsNullAndCreatedAtBefore(LocalDateTime localDateTime);
+
+    List<MagazineImage> findByCreatedAtBefore(LocalDateTime localDateTime);
 }

--- a/src/main/resources/static/websocket-test.html
+++ b/src/main/resources/static/websocket-test.html
@@ -125,8 +125,49 @@
             height: 100%;
             background-color: #f5c6cb;
         }
+        .button-group {
+            display: flex;
+            gap: 10px;
+            margin-top: 10px;
+        }
         
-    
+        .emoticon-container {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+            max-height: 200px;
+            overflow-y: auto;
+            margin-top: 10px;
+        }
+        
+        .emoticon-item {
+            width: 60px;
+            height: 60px;
+            border: 1px solid #ddd;
+            border-radius: 5px;
+            cursor: pointer;
+            overflow: hidden;
+            transition: transform 0.2s;
+        }
+        
+        .emoticon-item:hover {
+            transform: scale(1.1);
+            border-color: #0066cc;
+        }
+        
+        .emoticon-item img {
+            width: 100%;
+            height: 100%;
+            object-fit: contain;
+        }
+        
+        #emoticonBtn {
+            background-color: #f8f9fa;
+        }
+        
+        #emoticonBtn:hover {
+            background-color: #e9ecef;
+        }
     </style>
 </head>
 <body>
@@ -155,7 +196,21 @@
             <div class="form-group">
                 <label for="message">메시지:</label>
                 <textarea id="message" placeholder="보낼 메시지를 입력하세요" rows="3"></textarea>
-                <button onclick="sendMessage()">전송</button>
+                <div class="button-group">
+                    <button id="emoticonBtn" onclick="toggleEmoticonPanel()">😊 이모티콘</button>
+                    <button onclick="sendMessage()">전송</button>
+                </div>
+            </div>
+            
+            <!-- 이모티콘 선택 패널 -->
+            <div id="emoticonPanel" style="display:none; border: 1px solid #ccc; padding: 10px; margin-top: 10px; background-color: white; border-radius: 5px;">
+                <div class="emoticon-header">
+                    <h4>내 이모티콘</h4>
+                    <span onclick="toggleEmoticonPanel()" style="cursor:pointer; float:right;">×</span>
+                </div>
+                <div id="emoticonContainer" class="emoticon-container">
+                    <p>이모티콘을 불러오는 중...</p>
+                </div>
             </div>
             
             <div class="form-group">
@@ -320,6 +375,11 @@
             '/topic/chat.room.' + currentRoomId + '.toastbox',
             handleToastBoxEvent
         );
+        
+        subscriptions[`emoticon_${currentRoomId}`] = stompClient.subscribe(
+            '/topic/chat.room.' + currentRoomId + '.emoticon',
+            handleEmoticonMessage
+        );
     
         updatePresence('ONLINE', currentRoomId);
         markAsRead();
@@ -329,7 +389,7 @@
     }
     
     function unsubscribeRoom(roomId) {
-        ['room', 'read', 'reaction', 'customform', 'toastbox'].forEach(type => {
+        ['room', 'read', 'reaction', 'customform', 'toastbox', 'emoticon'].forEach(type => {
             const subKey = `${type}_${roomId}`;
             if (subscriptions[subKey]) {
                 try {
@@ -354,6 +414,114 @@
         updateRoomDisplay();
         document.getElementById('messages').innerHTML = '';
         logMessage("채팅방에서 퇴장했습니다", "info");
+    }
+    
+    // 이모티콘 메시지 처리
+    function handleEmoticonMessage(message) {
+        try {
+            const data = JSON.parse(message.body);
+            console.log("Emoticon message:", data);
+    
+            const emoticonMessage = {
+                id: data.messageId,
+                senderId: data.senderId,
+                senderName: data.senderName,
+                emoticonUrl: data.emoticonUrl,     // 이 필드!
+                emoticonName: data.emoticonName,   // 이 필드!
+                createdAt: data.timestamp,
+                type: 'EMOTICON'
+            };
+    
+            addMessageToDisplay(emoticonMessage);
+            logMessage(`이모티콘 메시지가 수신되었습니다: ${data.emoticonName}`, "info");
+        } catch (e) {
+            console.error("Error processing emoticon message:", e);
+        }
+    }
+
+    
+    // 이모티콘 패널 토글
+    function toggleEmoticonPanel() {
+        const panel = document.getElementById('emoticonPanel');
+        if (panel.style.display === 'none') {
+            panel.style.display = 'block';
+            fetchEmoticons();
+        } else {
+            panel.style.display = 'none';
+        }
+    }
+    
+    // 사용 가능한 이모티콘 조회
+    function fetchEmoticons() {
+        const token = document.getElementById('token').value;
+        if (!token) {
+            logMessage("토큰을 입력해주세요", "error");
+            return;
+        }
+        
+        logMessage("사용 가능한 이모티콘을 조회합니다...", "info");
+        
+        fetch(`${baseUrl}/api/emoticons/available`, {
+            method: 'GET',
+            headers: {
+                'Authorization': 'Bearer ' + token,
+                'Content-Type': 'application/json'
+            }
+        })
+        .then(response => {
+            if (!response.ok) throw new Error('이모티콘 조회 실패: ' + response.status);
+            return response.json();
+        })
+        .then(emoticons => {
+            displayEmoticons(emoticons);
+            logMessage(`${emoticons.length}개의 이모티콘을 불러왔습니다`, "success");
+        })
+        .catch(error => logMessage('이모티콘 조회 오류: ' + error.message, "error"));
+    }
+    
+    // 이모티콘 표시
+    function displayEmoticons(emoticons) {
+        const container = document.getElementById('emoticonContainer');
+        
+        if (!emoticons || emoticons.length === 0) {
+            container.innerHTML = '<p>사용 가능한 이모티콘이 없습니다.</p>';
+            return;
+        }
+        
+        container.innerHTML = '';
+        
+        emoticons.forEach(emoticon => {
+            const emoticonElement = document.createElement('div');
+            emoticonElement.className = 'emoticon-item';
+            emoticonElement.onclick = () => sendEmoticon(emoticon.id);
+            
+            const img = document.createElement('img');
+            img.src = `http://localhost:8080${emoticon.imageUrl}`;
+            img.alt = emoticon.name;
+            img.title = emoticon.name;
+            
+            emoticonElement.appendChild(img);
+            container.appendChild(emoticonElement);
+        });
+    }
+    
+    // 이모티콘 전송
+    function sendEmoticon(emoticonId) {
+        if (!stompClient || !currentRoomId) {
+            logMessage("먼저 채팅방에 입장해주세요", "error");
+            return;
+        }
+        
+        const emoticonRequest = {
+            roomId: currentRoomId,
+            emoticonId: emoticonId
+        };
+        
+        logMessage(`이모티콘 전송 중: ${JSON.stringify(emoticonRequest)}`, "info");
+        stompClient.send('/app/chat.emoticon', {}, JSON.stringify(emoticonRequest));
+        
+        // 이모티콘 패널 닫기
+        document.getElementById('emoticonPanel').style.display = 'none';
     }
 
     function sendMessage() {
@@ -478,6 +646,10 @@ function handleIncomingMessage(message) {
                 case 'CONTENT_FILTERED':
                     // 필터링된 메시지 처리
                     addMessageToDisplay(data.data);
+                    return;
+                 case 'EMOTICON':
+                    // 이모티콘 메시지 처리
+                    handleEmoticonMessage({ body: JSON.stringify(data.data) });
                     return;
             }
         }
@@ -864,8 +1036,19 @@ function addMessageToDisplay(message, isNew = true) {
             <span class="message-sender">${message.senderName || '알 수 없음'} ${isMyMessage ? '(나)' : ''}</span>
             <span class="message-time">${formatTime(message.createdAt)}</span>
         </div>
-        <div class="message-content">${message.content || ''}</div>
     `;
+    
+    // 메시지 타입에 따라 다른 내용 표시
+    if (message.type === 'EMOTICON') {
+        let emoticonImgUrl = message.emoticonUrl;
+        if (emoticonImgUrl && !emoticonImgUrl.startsWith('http')) {
+            emoticonImgUrl = `http://localhost:8080${emoticonImgUrl}`;
+        }
+        messageContent = `<img src="${emoticonImgUrl}" alt="${message.emoticonName || ''}" class="message-emoticon" style="max-height: 80px; max-width: 80px;">`;
+    } else {
+        messageContent += `<div class="message-content">${message.content || ''}</div>`;
+    }
+
 
     // 에러 메시지 표시
     if (message.error && message.errorMessage) {


### PR DESCRIPTION
## 🛰️ Issue Number
#80 

## 🪐 작업 내용
1. 매거진 작성 방식 수정 
기존: 한 번에 모든 텍스트 + list 단위로 이미지 이미 받음
변경: 블록 단위로 텍스트, 이미지, 이모티콘 처리 -> 네이버 블로그처럼 순서를 지키면서 확인
2. 매거진, 채팅에서 이모티콘 사용
