### PR TITLE
[Feat#122] 기본 이미지 중복 처리

### DIFF
--- a/src/main/java/com/mindmate/mindmate_server/user/domain/Profile.java
+++ b/src/main/java/com/mindmate/mindmate_server/user/domain/Profile.java
@@ -1,16 +1,13 @@
 package com.mindmate.mindmate_server.user.domain;
 
 import com.mindmate.mindmate_server.global.entity.BaseTimeEntity;
-import com.mindmate.mindmate_server.matching.domain.MatchingCategory;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 @Entity
 @Table(name = "profiles")
@@ -25,7 +22,7 @@ public class Profile extends BaseTimeEntity {
     @JoinColumn(name = "user_id", unique = true)
     private User user;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "profile_image_id")
     private ProfileImage profileImage;
 

--- a/src/main/java/com/mindmate/mindmate_server/user/repository/ProfileImageRepository.java
+++ b/src/main/java/com/mindmate/mindmate_server/user/repository/ProfileImageRepository.java
@@ -10,5 +10,5 @@ import java.util.Optional;
 public interface ProfileImageRepository extends JpaRepository<ProfileImage, Long> {
     Optional<ProfileImage> findByUserId(Long userId);
 
-    Optional<ProfileImage> findByOriginalName(String defaultImageFileName);
+    Optional<ProfileImage> findByOriginalNameAndUserIsNull(String defaultProfileImageFilename);
 }

--- a/src/main/java/com/mindmate/mindmate_server/user/service/ProfileImageService.java
+++ b/src/main/java/com/mindmate/mindmate_server/user/service/ProfileImageService.java
@@ -116,7 +116,7 @@ public class ProfileImageService {
 
     @Transactional(readOnly = true)
     public ProfileImage getDefaultProfileImage() {
-        return profileImageRepository.findByOriginalName(defaultProfileImageFilename)
+        return profileImageRepository.findByOriginalNameAndUserIsNull(defaultProfileImageFilename)
                 .orElseThrow(() -> new CustomException(ProfileErrorCode.PROFILE_IMAGE_NOT_FOUND));
     }
 


### PR DESCRIPTION
## 🛰️ Issue Number
#122 

## 🪐 작업 내용
1. 프로필 기본 이미지 중복 처리 (엔티티 연관관계 수정 및 originalName 중복이어도 제대로 설정하게끔)
