### PR TITLE
[Feat#188] 테스트 코드 및 카프카 컨슈머, 프론트 요구사항 추가

### DIFF
--- a/src/main/java/com/mindmate/mindmate_server/auth/util/JwtTokenProvider.java
+++ b/src/main/java/com/mindmate/mindmate_server/auth/util/JwtTokenProvider.java
@@ -74,10 +74,6 @@ public class JwtTokenProvider {
                 .compact();
     }
 
-    private boolean isProfileComplete(User user) {
-        return user.getCurrentRole() != RoleType.ROLE_UNVERIFIED && user.getCurrentRole() != RoleType.ROLE_USER;
-    }
-
     /**
      * 변조 방지
      */

--- a/src/main/java/com/mindmate/mindmate_server/auth/util/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/mindmate/mindmate_server/auth/util/OAuth2AuthenticationSuccessHandler.java
@@ -95,6 +95,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
                     .queryParam("token", accessToken)
                     .queryParam("refreshToken", refreshToken)
                     .queryParam("email", user.getEmail())
+                    .queryParam("role", user.getCurrentRole().name())
                     .build().toUriString();
             return targetUrl;
         } catch (Exception e) {

--- a/src/main/java/com/mindmate/mindmate_server/chat/service/ChatNotificationConsumer.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/service/ChatNotificationConsumer.java
@@ -25,7 +25,12 @@ public class ChatNotificationConsumer {
 //    @KafkaStandardRetry
     @RetryableTopic(
             attempts = "3",
-            backoff = @Backoff(delay = 1000),
+            backoff = @Backoff(
+                    delay = 1000,
+                    multiplier = 2.0,
+                    maxDelay = 10000,
+                    random = true
+            ),
             dltTopicSuffix = "-notification-group-dlt",
             retryTopicSuffix = "-notification-group-retry"
     )

--- a/src/main/java/com/mindmate/mindmate_server/chat/service/ChatRoomCloseNotificationConsumer.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/service/ChatRoomCloseNotificationConsumer.java
@@ -22,7 +22,12 @@ public class ChatRoomCloseNotificationConsumer {
 //    @KafkaStandardRetry
     @RetryableTopic(
             attempts = "3",
-            backoff = @Backoff(delay = 1000),
+            backoff = @Backoff(
+                    delay = 1000,
+                    multiplier = 2.0,
+                    maxDelay = 10000,
+                    random = true
+            ),
             dltTopicSuffix = "-chat-notification-group-dlt",
             retryTopicSuffix = "-chat-notification-group-retry"
     )

--- a/src/main/java/com/mindmate/mindmate_server/chat/service/FilteringEventConsumer.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/service/FilteringEventConsumer.java
@@ -32,7 +32,12 @@ public class FilteringEventConsumer {
 //    @KafkaStandardRetry
     @RetryableTopic(
             attempts = "3",
-            backoff = @Backoff(delay = 1000),
+            backoff = @Backoff(
+                    delay = 1000,
+                    multiplier = 2.0,
+                    maxDelay = 10000,
+                    random = true
+            ),
             dltTopicSuffix = "-filtering-event-group-dlt",
             retryTopicSuffix = "-filtering-event-group-retry"
     )

--- a/src/main/java/com/mindmate/mindmate_server/chat/service/ResponseTimeCalculationConsumer.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/service/ResponseTimeCalculationConsumer.java
@@ -33,7 +33,12 @@ public class ResponseTimeCalculationConsumer {
 //    @KafkaStandardRetry
     @RetryableTopic(
             attempts = "3",
-            backoff = @Backoff(delay = 1000),
+            backoff = @Backoff(
+                    delay = 1000,
+                    multiplier = 2.0,
+                    maxDelay = 10000,
+                    random = true
+            ),
             dltTopicSuffix = "-response-time-calculation-group-dlt",
             retryTopicSuffix = "-response-time-calculation-group-retry"
     )

--- a/src/main/java/com/mindmate/mindmate_server/chat/service/ToastBoxConsumer.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/service/ToastBoxConsumer.java
@@ -27,7 +27,12 @@ public class ToastBoxConsumer {
 //    @KafkaStandardRetry
     @RetryableTopic(
             attempts = "3",
-            backoff = @Backoff(delay = 1000),
+            backoff = @Backoff(
+                    delay = 1000,
+                    multiplier = 2.0,
+                    maxDelay = 10000,
+                    random = true
+            ),
             dltTopicSuffix = "-toast-box-group-dlt",
             retryTopicSuffix = "-toast-box-group-retry"
     )

--- a/src/main/java/com/mindmate/mindmate_server/chat/service/UnreadCountConsumer.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/service/UnreadCountConsumer.java
@@ -26,7 +26,12 @@ public class UnreadCountConsumer {
 //    @KafkaStandardRetry
     @RetryableTopic(
             attempts = "3",
-            backoff = @Backoff(delay = 1000),
+            backoff = @Backoff(
+                    delay = 1000,
+                    multiplier = 2.0,
+                    maxDelay = 10000,
+                    random = true
+            ),
             dltTopicSuffix = "-unread-count-group-dlt",
             retryTopicSuffix = "-unread-count-group-retry"
     )

--- a/src/main/java/com/mindmate/mindmate_server/magazine/service/MagazineEngagementConsumer.java
+++ b/src/main/java/com/mindmate/mindmate_server/magazine/service/MagazineEngagementConsumer.java
@@ -25,7 +25,12 @@ public class MagazineEngagementConsumer {
 //    @KafkaStandardRetry
     @RetryableTopic(
             attempts = "3",
-            backoff = @Backoff(delay = 1000),
+            backoff = @Backoff(
+                    delay = 1000,
+                    multiplier = 2.0,
+                    maxDelay = 10000,
+                    random = true
+            ),
             dltTopicSuffix = "-magazine-engagement-group-dlt",
             retryTopicSuffix = "-magazine-engagement-group-retry"
     )

--- a/src/main/java/com/mindmate/mindmate_server/matching/service/MatchingEventConsumer.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/service/MatchingEventConsumer.java
@@ -22,7 +22,12 @@ public class MatchingEventConsumer {
 //    @KafkaStandardRetry
     @RetryableTopic(
             attempts = "3",
-            backoff = @Backoff(delay = 1000),
+            backoff = @Backoff(
+                    delay = 1000,
+                    multiplier = 2.0,
+                    maxDelay = 10000,
+                    random = true
+            ),
             dltTopicSuffix = "-matching-group-dlt",
             retryTopicSuffix = "-matching-group-retry"
     )

--- a/src/main/java/com/mindmate/mindmate_server/report/dto/UnsuspendRequest.java
+++ b/src/main/java/com/mindmate/mindmate_server/report/dto/UnsuspendRequest.java
@@ -11,4 +11,8 @@ import lombok.NoArgsConstructor;
 @Builder
 public class UnsuspendRequest {
     private int reportCount;
+
+    public void setReportCount(Integer count) {
+        this.reportCount = count;
+    }
 }

--- a/src/main/java/com/mindmate/mindmate_server/user/domain/RoleType.java
+++ b/src/main/java/com/mindmate/mindmate_server/user/domain/RoleType.java
@@ -6,7 +6,6 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum RoleType {
-    ROLE_UNVERIFIED("ROLE_UNVERIFIED", "이메일 인증 안한 사용자"),
     ROLE_USER("ROLE_USER", "프로필 입력 안한 사용자"),
     ROLE_PROFILE("ROLE_PROFILE", "프로필 입력 한 사용자"),
     // todo: 해당 status일때 api 호출 제한

--- a/src/test/java/com/mindmate/mindmate_server/global/service/FileStorageServiceTest.java
+++ b/src/test/java/com/mindmate/mindmate_server/global/service/FileStorageServiceTest.java
@@ -1,0 +1,373 @@
+package com.mindmate.mindmate_server.global.service;
+
+import com.mindmate.mindmate_server.global.dto.FileInfo;
+import com.mindmate.mindmate_server.global.exception.CommonErrorCode;
+import com.mindmate.mindmate_server.global.exception.CustomException;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.imageio.ImageIO;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.*;
+import java.lang.reflect.Method;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class FileStorageServiceTest {
+
+    @InjectMocks
+    private FileStorageService fileStorageService;
+
+    @Mock private MultipartFile mockFile;
+
+    private final String TEST_DIRECTORY = "test-uploads";
+    private final String TEST_ORIGINAL_FILENAME = "test-image.jpg";
+    private final String TEST_CONTENT_TYPE = "image/jpeg";
+    private final byte[] TEST_IMAGE_BYTES = createTestImageBytes();
+
+    @BeforeEach
+    void setUp() {
+        setupMockFile();
+        cleanupTestDirectory();
+    }
+
+    @AfterEach
+    void tearDown() {
+        cleanupTestDirectory();
+    }
+
+    private void setupMockFile() {
+        when(mockFile.getOriginalFilename()).thenReturn(TEST_ORIGINAL_FILENAME);
+        when(mockFile.getContentType()).thenReturn(TEST_CONTENT_TYPE);
+        when(mockFile.isEmpty()).thenReturn(false);
+        when(mockFile.getSize()).thenReturn((long) TEST_IMAGE_BYTES.length);
+    }
+
+    private void cleanupTestDirectory() {
+        File testDir = new File(TEST_DIRECTORY);
+        if (testDir.exists()) {
+            File[] files = testDir.listFiles();
+            if (files != null) {
+                for (File file : files) {
+                    file.delete();
+                }
+            }
+            testDir.delete();
+        }
+    }
+
+    private static byte[] createTestImageBytes() {
+        BufferedImage image = new BufferedImage(100, 100, BufferedImage.TYPE_INT_RGB);
+        Graphics2D g2d = image.createGraphics();
+        g2d.setColor(Color.BLUE);
+        g2d.fillRect(0, 0, 100, 100);
+        g2d.dispose();
+
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            ImageIO.write(image, "jpg", baos);
+            return baos.toByteArray();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Nested
+    @DisplayName("storeFile 테스트")
+    class StoreFileTest {
+
+        @Test
+        @DisplayName("정상적인 이미지 파일 저장 성공")
+        void storeFile_Success() throws IOException {
+            // given
+            InputStream inputStream = new ByteArrayInputStream(TEST_IMAGE_BYTES);
+            when(mockFile.getInputStream()).thenReturn(inputStream);
+
+            // when
+            FileInfo result = fileStorageService.storeFile(mockFile, TEST_DIRECTORY);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.getOriginalFileName()).isEqualTo(TEST_ORIGINAL_FILENAME);
+            assertThat(result.getStoredFileName()).endsWith(".jpg");
+            assertThat(result.getContentType()).isEqualTo(TEST_CONTENT_TYPE);
+            assertThat(result.getFileSize()).isGreaterThan(0);
+
+            File savedFile = new File(TEST_DIRECTORY, result.getStoredFileName());
+            assertThat(savedFile).exists();
+            assertThat(savedFile.length()).isEqualTo(result.getFileSize());
+        }
+
+        @ParameterizedTest(name = "[{index}] 파일명: {0}, 확장자: {1}")
+        @MethodSource("fileExtensionScenarios")
+        @DisplayName("다양한 파일 확장자 처리")
+        void storeFile_VariousExtensions(String filename, String expectedExtension) throws IOException {
+            // given
+            when(mockFile.getOriginalFilename()).thenReturn(filename);
+            InputStream inputStream = new ByteArrayInputStream(TEST_IMAGE_BYTES);
+            when(mockFile.getInputStream()).thenReturn(inputStream);
+
+            // when
+            FileInfo result = fileStorageService.storeFile(mockFile, TEST_DIRECTORY);
+
+            // then
+            assertThat(result.getStoredFileName()).endsWith("." + expectedExtension);
+        }
+
+        static Stream<Arguments> fileExtensionScenarios() {
+            return Stream.of(
+                    Arguments.of("image.jpg", "jpg"),
+                    Arguments.of("image.png", "png"),
+                    Arguments.of("image.gif", "gif"),
+                    Arguments.of("image.jpeg", "jpeg"),
+                    Arguments.of("image", "png"),
+                    Arguments.of(null, "png")
+            );
+        }
+
+        @Test
+        @DisplayName("디렉토리가 존재하지 않는 경우 자동 생성")
+        void storeFile_CreateDirectoryIfNotExists() throws IOException {
+            // given
+            String nonExistentDir = "non-existent-dir/sub-dir";
+            InputStream inputStream = new ByteArrayInputStream(TEST_IMAGE_BYTES);
+            when(mockFile.getInputStream()).thenReturn(inputStream);
+
+            // when
+            FileInfo result = fileStorageService.storeFile(mockFile, nonExistentDir);
+
+            // then
+            File createdDir = new File(nonExistentDir);
+            assertThat(createdDir).exists();
+            assertThat(createdDir).isDirectory();
+
+            File savedFile = new File(nonExistentDir, result.getStoredFileName());
+            savedFile.delete();
+            createdDir.delete();
+            new File("non-existent-dir").delete();
+        }
+
+        @Test
+        @DisplayName("파일 저장 중 예외 발생 시 생성된 파일 삭제")
+        void storeFile_ExceptionHandling_DeletesFile() throws IOException {
+            // given
+            byte[] invalidImageData = "invalid image data".getBytes();
+            InputStream inputStream = new ByteArrayInputStream(invalidImageData);
+            when(mockFile.getInputStream()).thenReturn(inputStream);
+
+            // when & then
+            assertThrows(IllegalArgumentException.class,
+                    () -> fileStorageService.storeFile(mockFile, TEST_DIRECTORY));
+        }
+
+
+        @Test
+        @DisplayName("UUID를 사용한 고유한 파일명 생성")
+        void storeFile_GeneratesUniqueFilenames() throws IOException {
+            // given
+            InputStream inputStream1 = new ByteArrayInputStream(TEST_IMAGE_BYTES);
+            InputStream inputStream2 = new ByteArrayInputStream(TEST_IMAGE_BYTES);
+            when(mockFile.getInputStream()).thenReturn(inputStream1, inputStream2);
+
+            // when
+            FileInfo result1 = fileStorageService.storeFile(mockFile, TEST_DIRECTORY);
+            FileInfo result2 = fileStorageService.storeFile(mockFile, TEST_DIRECTORY);
+
+            // then
+            assertThat(result1.getStoredFileName()).isNotEqualTo(result2.getStoredFileName());
+            assertThat(result1.getStoredFileName()).matches("^[a-f0-9\\-]{36}\\.jpg$");
+            assertThat(result2.getStoredFileName()).matches("^[a-f0-9\\-]{36}\\.jpg$");
+        }
+    }
+
+    @Nested
+    @DisplayName("storeFileAsWebp 테스트")
+    class StoreFileAsWebpTest {
+
+        @Test
+        @DisplayName("이미지를 WebP 형식으로 변환하여 저장")
+        void storeFileAsWebp_Success() throws IOException {
+            // given
+            InputStream inputStream = new ByteArrayInputStream(TEST_IMAGE_BYTES);
+            when(mockFile.getInputStream()).thenReturn(inputStream);
+
+            // when
+            FileInfo result = fileStorageService.storeFileAsWebp(mockFile, TEST_DIRECTORY);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.getOriginalFileName()).isEqualTo(TEST_ORIGINAL_FILENAME);
+            assertThat(result.getStoredFileName()).endsWith(".webp");
+            assertThat(result.getContentType()).isEqualTo("image/webp");
+            assertThat(result.getFileSize()).isGreaterThan(0);
+
+            File savedFile = new File(TEST_DIRECTORY, result.getStoredFileName());
+            assertThat(savedFile).exists();
+        }
+
+        @Test
+        @DisplayName("WebP 변환 중 예외 발생 시 파일 삭제")
+        void storeFileAsWebp_ExceptionHandling() throws IOException {
+            // given
+            byte[] invalidImageData = "invalid image data".getBytes();
+            InputStream inputStream = new ByteArrayInputStream(invalidImageData);
+            when(mockFile.getInputStream()).thenReturn(inputStream);
+
+            // when & then
+            assertThrows(IllegalArgumentException.class,
+                    () -> fileStorageService.storeFileAsWebp(mockFile, TEST_DIRECTORY));
+        }
+
+
+        @Test
+        @DisplayName("WebP 파일명이 UUID 형식으로 생성됨")
+        void storeFileAsWebp_GeneratesUuidFilename() throws IOException {
+            // given
+            InputStream inputStream = new ByteArrayInputStream(TEST_IMAGE_BYTES);
+            when(mockFile.getInputStream()).thenReturn(inputStream);
+
+            // when
+            FileInfo result = fileStorageService.storeFileAsWebp(mockFile, TEST_DIRECTORY);
+
+            // then
+            assertThat(result.getStoredFileName()).matches("^[a-f0-9\\-]{36}\\.webp$");
+        }
+    }
+
+    @Nested
+    @DisplayName("validateFile 테스트")
+    class ValidateFileTest {
+
+        @Test
+        @DisplayName("정상적인 이미지 파일 검증 통과")
+        void validateFile_ValidImageFile_Success() {
+            // given
+            when(mockFile.isEmpty()).thenReturn(false);
+            when(mockFile.getContentType()).thenReturn("image/jpeg");
+
+            // when & then
+            assertDoesNotThrow(() -> fileStorageService.validateFile(mockFile));
+        }
+
+        @ParameterizedTest(name = "[{index}] Content-Type: {0}")
+        @ValueSource(strings = {"image/jpeg", "image/png", "image/gif", "image/webp", "image/bmp"})
+        @DisplayName("다양한 이미지 타입 검증 통과")
+        void validateFile_VariousImageTypes_Success(String contentType) {
+            // given
+            when(mockFile.isEmpty()).thenReturn(false);
+            when(mockFile.getContentType()).thenReturn(contentType);
+
+            // when & then
+            assertDoesNotThrow(() -> fileStorageService.validateFile(mockFile));
+        }
+
+        @Test
+        @DisplayName("null 파일 검증 시 예외 발생")
+        void validateFile_NullFile_ThrowsException() {
+            // when & then
+            CustomException exception = assertThrows(CustomException.class,
+                    () -> fileStorageService.validateFile(null));
+
+            assertThat(exception.getErrorCode()).isEqualTo(CommonErrorCode.EMPTY_FILE);
+        }
+
+        @Test
+        @DisplayName("빈 파일 검증 시 예외 발생")
+        void validateFile_EmptyFile_ThrowsException() {
+            // given
+            when(mockFile.isEmpty()).thenReturn(true);
+
+            // when & then
+            CustomException exception = assertThrows(CustomException.class,
+                    () -> fileStorageService.validateFile(mockFile));
+
+            assertThat(exception.getErrorCode()).isEqualTo(CommonErrorCode.EMPTY_FILE);
+        }
+
+        @ParameterizedTest(name = "[{index}] Content-Type: {0}")
+        @ValueSource(strings = {"text/plain", "application/pdf", "video/mp4", "audio/mp3"})
+        @DisplayName("이미지가 아닌 파일 타입 검증 시 예외 발생")
+        void validateFile_NonImageType_ThrowsException(String contentType) {
+            // given
+            when(mockFile.isEmpty()).thenReturn(false);
+            when(mockFile.getContentType()).thenReturn(contentType);
+
+            // when & then
+            CustomException exception = assertThrows(CustomException.class,
+                    () -> fileStorageService.validateFile(mockFile));
+
+            assertThat(exception.getErrorCode()).isEqualTo(CommonErrorCode.INVALID_FILE_TYPE);
+        }
+
+        @Test
+        @DisplayName("Content-Type이 null인 경우 예외 발생")
+        void validateFile_NullContentType_ThrowsException() {
+            // given
+            when(mockFile.isEmpty()).thenReturn(false);
+            when(mockFile.getContentType()).thenReturn(null);
+
+            // when & then
+            CustomException exception = assertThrows(CustomException.class,
+                    () -> fileStorageService.validateFile(mockFile));
+
+            assertThat(exception.getErrorCode()).isEqualTo(CommonErrorCode.INVALID_FILE_TYPE);
+        }
+    }
+
+    @Nested
+    @DisplayName("getExtension 테스트")
+    class GetExtensionTest {
+
+        @ParameterizedTest(name = "[{index}] 파일명: {0}, 예상 확장자: {1}")
+        @MethodSource("extensionScenarios")
+        @DisplayName("파일 확장자 추출 테스트")
+        void getExtension_VariousFilenames(String filename, String expectedExtension) {
+            // when
+            String result = invokeGetExtension(filename);
+
+            // then
+            assertThat(result).isEqualTo(expectedExtension);
+        }
+
+        static Stream<Arguments> extensionScenarios() {
+            return Stream.of(
+                    Arguments.of("image.jpg", "jpg"),
+                    Arguments.of("image.png", "png"),
+                    Arguments.of("image.jpeg", "jpeg"),
+                    Arguments.of("file.with.multiple.dots.gif", "gif"),
+                    Arguments.of("noextension", "png"),
+                    Arguments.of("", "png"),
+                    Arguments.of(null, "png"),
+                    Arguments.of("file.", ""),
+                    Arguments.of(".hiddenfile", "hiddenfile")
+            );
+        }
+
+        private String invokeGetExtension(String filename) {
+            try {
+                Method method = FileStorageService.class.getDeclaredMethod("getExtension", String.class);
+                method.setAccessible(true);
+                return (String) method.invoke(fileStorageService, filename);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+}

--- a/src/test/java/com/mindmate/mindmate_server/user/service/AdminUserSuspensionServiceTest.java
+++ b/src/test/java/com/mindmate/mindmate_server/user/service/AdminUserSuspensionServiceTest.java
@@ -1,0 +1,249 @@
+package com.mindmate.mindmate_server.user.service;
+
+import com.mindmate.mindmate_server.global.exception.CustomException;
+import com.mindmate.mindmate_server.global.exception.UserErrorCode;
+import com.mindmate.mindmate_server.global.util.RedisKeyManager;
+import com.mindmate.mindmate_server.global.util.SlackNotifier;
+import com.mindmate.mindmate_server.report.dto.UnsuspendRequest;
+import com.mindmate.mindmate_server.user.domain.Profile;
+import com.mindmate.mindmate_server.user.domain.RoleType;
+import com.mindmate.mindmate_server.user.domain.User;
+import com.mindmate.mindmate_server.user.dto.SuspendedUserDTO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class AdminUserSuspensionServiceTest {
+
+    @Mock private UserService userService;
+    @Mock private RedisTemplate<String, Object> redisTemplate;
+    @Mock private ValueOperations<String, Object> valueOperations;
+    @Mock private RedisKeyManager redisKeyManager;
+    @Mock private SlackNotifier slackNotifier;
+
+    @InjectMocks
+    private AdminUserSuspensionService adminUserSuspensionService;
+
+    private User mockUser;
+    private User mockAdminUser;
+    private Profile mockProfile;
+    private final Long TEST_USER_ID = 1L;
+    private final Long TEST_ADMIN_ID = 2L;
+    private final String TEST_EMAIL = "test@example.com";
+    private final String TEST_SUSPENSION_KEY = "user:suspension:1";
+    private final String TEST_REASON = "부적절한 행동";
+    private final String TEST_NICKNAME = "testUser";
+
+    @BeforeEach
+    void setUp() {
+        setupMockObjects();
+        setupMockBehaviors();
+        setupRedisOperations();
+    }
+
+    private void setupMockObjects() {
+        mockUser = mock(User.class);
+        mockAdminUser = mock(User.class);
+        mockProfile = mock(Profile.class);
+    }
+
+    private void setupMockBehaviors() {
+        when(mockUser.getId()).thenReturn(TEST_USER_ID);
+        when(mockUser.getEmail()).thenReturn(TEST_EMAIL);
+        when(mockUser.getCurrentRole()).thenReturn(RoleType.ROLE_USER);
+        when(mockUser.getProfile()).thenReturn(mockProfile);
+        when(mockUser.getReportCount()).thenReturn(0);
+
+        when(mockAdminUser.getId()).thenReturn(TEST_ADMIN_ID);
+        when(mockAdminUser.getCurrentRole()).thenReturn(RoleType.ROLE_ADMIN);
+
+        when(mockProfile.getNickname()).thenReturn(TEST_NICKNAME);
+
+        when(userService.findUserById(TEST_USER_ID)).thenReturn(mockUser);
+        when(userService.findUserById(TEST_ADMIN_ID)).thenReturn(mockAdminUser);
+    }
+
+    private void setupRedisOperations() {
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(redisKeyManager.getUserSuspensionKey(TEST_USER_ID)).thenReturn(TEST_SUSPENSION_KEY);
+    }
+
+    @Nested
+    @DisplayName("suspendUser 테스트")
+    class SuspendUserTest {
+
+        @Test
+        @DisplayName("일반 사용자 정지 성공 - 일 단위")
+        void suspendUser_Success_Days() {
+            // given
+            Duration duration = Duration.ofDays(7);
+            int reportCount = 3;
+
+            // when
+            adminUserSuspensionService.suspendUser(TEST_USER_ID, reportCount, duration, TEST_REASON);
+
+            // then
+            verify(userService).findUserById(TEST_USER_ID);
+            verify(userService).save(mockUser);
+            verify(valueOperations).set(TEST_SUSPENSION_KEY, "suspended");
+            verify(redisTemplate).expire(TEST_SUSPENSION_KEY, 7L, TimeUnit.DAYS);
+            verify(slackNotifier).sendSuspensionAlert(mockUser, TEST_REASON, duration);
+            verify(mockUser).suspend(duration);
+            verify(mockUser).setReportCount(reportCount);
+        }
+
+        @Test
+        @DisplayName("일반 사용자 정지 성공 - 시간 단위")
+        void suspendUser_Success_Hours() {
+            // given
+            Duration duration = Duration.ofHours(12);
+            int reportCount = 2;
+
+            // when
+            adminUserSuspensionService.suspendUser(TEST_USER_ID, reportCount, duration, TEST_REASON);
+
+            // then
+            verify(redisTemplate).expire(TEST_SUSPENSION_KEY, 12L, TimeUnit.HOURS);
+            verify(mockUser).suspend(duration);
+        }
+
+        @Test
+        @DisplayName("관리자 정지 시도 시 예외 발생")
+        void suspendUser_AdminUser_ThrowsException() {
+            // given
+            Duration duration = Duration.ofDays(1);
+
+            // when & then
+            CustomException exception = assertThrows(CustomException.class,
+                    () -> adminUserSuspensionService.suspendUser(TEST_ADMIN_ID, 1, duration, TEST_REASON));
+
+            assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.ADMIN_SUSPENSION_NOT_ALLOWED);
+            verify(userService, never()).save(any());
+            verify(valueOperations, never()).set(anyString(), any());
+        }
+
+        @Test
+        @DisplayName("음수 신고 횟수로 정지 시 신고 횟수 업데이트 안함")
+        void suspendUser_NegativeReportCount_DoesNotUpdate() {
+            // given
+            Duration duration = Duration.ofDays(1);
+
+            // when
+            adminUserSuspensionService.suspendUser(TEST_USER_ID, -1, duration, TEST_REASON);
+
+            // then
+            verify(mockUser, never()).setReportCount(anyInt());
+            verify(userService).save(mockUser);
+        }
+    }
+
+    @Nested
+    @DisplayName("unsuspendUser 테스트")
+    class UnsuspendUserTest {
+
+        @Test
+        @DisplayName("정지된 사용자 정지 해제 성공")
+        void unsuspendUser_Success() {
+            // given
+            UnsuspendRequest request = new UnsuspendRequest();
+            request.setReportCount(1);
+
+            when(mockUser.getCurrentRole()).thenReturn(RoleType.ROLE_SUSPENDED);
+
+            // when
+            adminUserSuspensionService.unsuspendUser(TEST_USER_ID, request);
+
+            // then
+            verify(userService).findUserById(TEST_USER_ID);
+            verify(userService).save(mockUser);
+            verify(redisTemplate).delete(TEST_SUSPENSION_KEY);
+            verify(mockUser).setReportCount(1);
+            verify(mockUser).unsuspend();
+        }
+
+        @Test
+        @DisplayName("이미 정지되지 않은 사용자 정지 해제 시도 시 예외 발생")
+        void unsuspendUser_AlreadyNotSuspended_ThrowsException() {
+            // given
+            UnsuspendRequest request = new UnsuspendRequest();
+            when(mockUser.getCurrentRole()).thenReturn(RoleType.ROLE_USER);
+
+            // when & then
+            CustomException exception = assertThrows(CustomException.class,
+                    () -> adminUserSuspensionService.unsuspendUser(TEST_USER_ID, request));
+
+            assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.USER_ALREADY_NOT_SUSPENDED);
+            verify(userService, never()).save(any());
+            verify(redisTemplate, never()).delete(anyString());
+        }
+    }
+
+    @Nested
+    @DisplayName("getAllSuspendedUsers 테스트")
+    class GetAllSuspendedUsersTest {
+
+        @Test
+        @DisplayName("정지된 사용자 목록 조회 성공")
+        void getAllSuspendedUsers_Success() {
+            // given
+            Set<String> suspensionKeys = Set.of("user:suspension:1", "user:suspension:2");
+            LocalDateTime suspensionEndTime = LocalDateTime.now().plusDays(7);
+
+            when(mockUser.getSuspensionEndTime()).thenReturn(suspensionEndTime);
+            when(mockUser.getReportCount()).thenReturn(3);
+
+            when(redisTemplate.keys("user:suspension:*")).thenReturn(suspensionKeys);
+            when(userService.findUserById(1L)).thenReturn(mockUser);
+            when(userService.findUserById(2L)).thenReturn(mockUser);
+            when(valueOperations.get("user:suspension:1")).thenReturn("부적절한 행동");
+            when(valueOperations.get("user:suspension:2")).thenReturn("스팸");
+
+            // when
+            List<SuspendedUserDTO> result = adminUserSuspensionService.getAllSuspendedUsers();
+
+            // then
+            assertThat(result).hasSize(2);
+            verify(redisTemplate).keys("user:suspension:*");
+            verify(userService, times(2)).findUserById(anyLong());
+        }
+
+        @Test
+        @DisplayName("Redis에서 정지 사유를 가져올 수 없는 경우 Unknown으로 설정")
+        void getAllSuspendedUsers_UnknownReason() {
+            // given
+            Set<String> suspensionKeys = Set.of("user:suspension:1");
+
+            when(redisTemplate.keys("user:suspension:*")).thenReturn(suspensionKeys);
+            when(userService.findUserById(1L)).thenReturn(mockUser);
+            when(valueOperations.get("user:suspension:1")).thenReturn(null);
+
+            // when
+            List<SuspendedUserDTO> result = adminUserSuspensionService.getAllSuspendedUsers();
+
+            // then
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).getSuspensionReason()).isEqualTo("Unknown");
+        }
+    }
+}

--- a/src/test/java/com/mindmate/mindmate_server/user/service/ProfileImageServiceTest.java
+++ b/src/test/java/com/mindmate/mindmate_server/user/service/ProfileImageServiceTest.java
@@ -1,0 +1,432 @@
+package com.mindmate.mindmate_server.user.service;
+
+import com.mindmate.mindmate_server.global.dto.FileInfo;
+import com.mindmate.mindmate_server.global.exception.CommonErrorCode;
+import com.mindmate.mindmate_server.global.exception.CustomException;
+import com.mindmate.mindmate_server.global.exception.ProfileErrorCode;
+import com.mindmate.mindmate_server.global.service.FileStorageService;
+import com.mindmate.mindmate_server.user.domain.Profile;
+import com.mindmate.mindmate_server.user.domain.ProfileImage;
+import com.mindmate.mindmate_server.user.domain.User;
+import com.mindmate.mindmate_server.user.dto.ProfileImageResponse;
+import com.mindmate.mindmate_server.user.repository.ProfileImageRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ProfileImageServiceTest {
+
+    @Mock private FileStorageService fileStorageService;
+    @Mock private ProfileImageRepository profileImageRepository;
+    @Mock private UserService userService;
+    @Mock private MultipartFile mockFile;
+
+    @InjectMocks
+    private ProfileImageService profileImageService;
+
+    private final Long TEST_USER_ID = 1L;
+    private final Long TEST_IMAGE_ID = 10L;
+    private final String TEST_PROFILE_DIR = "test-profiles/";
+    private final String TEST_URL_PREFIX = "http://localhost:8080/images/";
+    private final String TEST_DEFAULT_FILENAME = "default-profile.png";
+
+    @BeforeEach
+    void setUp() {
+        setupTestProperties();
+    }
+
+    private void setupTestProperties() {
+        ReflectionTestUtils.setField(profileImageService, "profileImageDir", TEST_PROFILE_DIR);
+        ReflectionTestUtils.setField(profileImageService, "profileImageUrlPrefix", TEST_URL_PREFIX);
+        ReflectionTestUtils.setField(profileImageService, "defaultProfileImageFilename", TEST_DEFAULT_FILENAME);
+    }
+
+    static class TestDataBuilder {
+        static User createMockUser(Long userId) {
+            User user = mock(User.class);
+            Profile profile = mock(Profile.class);
+            ProfileImage profileImage = mock(ProfileImage.class);
+
+            when(user.getId()).thenReturn(userId);
+            when(user.getProfile()).thenReturn(profile);
+            when(profile.getProfileImage()).thenReturn(profileImage);
+
+            return user;
+        }
+
+        static ProfileImage createMockProfileImage(Long id, Long userId, String storedName) {
+            ProfileImage profileImage = mock(ProfileImage.class);
+            User user = mock(User.class);
+            when(user.getId()).thenReturn(userId);
+
+            when(profileImage.getId()).thenReturn(id);
+            when(profileImage.getUser()).thenReturn(user);
+            when(profileImage.getStoredName()).thenReturn(storedName);
+            when(profileImage.getOriginalName()).thenReturn("test-image.jpg");
+            when(profileImage.getImageUrl()).thenReturn("http://localhost:8080/images/" + storedName);
+            when(profileImage.getContentType()).thenReturn("image/webp");
+            when(profileImage.getFileSize()).thenReturn(1024L);
+
+            return profileImage;
+        }
+
+        static FileInfo createMockFileInfo(String originalName, String storedName) {
+            FileInfo fileInfo = mock(FileInfo.class);
+            when(fileInfo.getOriginalFileName()).thenReturn(originalName);
+            when(fileInfo.getStoredFileName()).thenReturn(storedName);
+            when(fileInfo.getFileSize()).thenReturn(1024L);
+            return fileInfo;
+        }
+    }
+
+    @Nested
+    @DisplayName("uploadProfileImage 테스트")
+    class UploadProfileImageTest {
+
+        @ParameterizedTest(name = "[{index}] {0}")
+        @MethodSource("uploadScenarios")
+        @DisplayName("다양한 업로드 시나리오")
+        void uploadProfileImage_VariousScenarios(
+                String description,
+                boolean hasExistingImage,
+                boolean shouldThrowException,
+                Class<? extends Exception> expectedExceptionType) throws IOException {
+
+            // given
+            User mockUser = TestDataBuilder.createMockUser(TEST_USER_ID);
+            when(userService.findUserById(TEST_USER_ID)).thenReturn(mockUser);
+
+            if (hasExistingImage) {
+                ProfileImage existingImage = TestDataBuilder.createMockProfileImage(1L, TEST_USER_ID, "old-image.jpg");
+                when(profileImageRepository.findByUserId(TEST_USER_ID)).thenReturn(Optional.of(existingImage));
+            } else {
+                when(profileImageRepository.findByUserId(TEST_USER_ID)).thenReturn(Optional.empty());
+            }
+
+            if (shouldThrowException) {
+                when(fileStorageService.storeFile(mockFile, TEST_PROFILE_DIR))
+                        .thenThrow(new IOException("Storage failed"));
+            } else {
+                FileInfo fileInfo = TestDataBuilder.createMockFileInfo("test.jpg", "uuid-test.jpg");
+                when(fileStorageService.storeFile(mockFile, TEST_PROFILE_DIR)).thenReturn(fileInfo);
+
+                ProfileImage savedImage = TestDataBuilder.createMockProfileImage(TEST_IMAGE_ID, TEST_USER_ID, "uuid-test.jpg");
+                when(profileImageRepository.save(any(ProfileImage.class))).thenReturn(savedImage);
+            }
+
+            // when & then
+            if (shouldThrowException) {
+                CustomException exception = assertThrows(CustomException.class,
+                        () -> profileImageService.uploadProfileImage(TEST_USER_ID, mockFile));
+                assertThat(exception.getErrorCode()).isEqualTo(ProfileErrorCode.IMAGE_UPLOAD_ERROR);
+            } else {
+                ProfileImageResponse result = profileImageService.uploadProfileImage(TEST_USER_ID, mockFile);
+
+                assertThat(result).isNotNull();
+                assertThat(result.getStoredFileName()).isEqualTo("uuid-test.jpg");
+                assertThat(result.getContentType()).isEqualTo("image/webp");
+
+                verify(fileStorageService).validateFile(mockFile);
+                verify(profileImageRepository).save(any(ProfileImage.class));
+
+                if (hasExistingImage) {
+                    verify(profileImageRepository).delete(any(ProfileImage.class));
+                }
+            }
+        }
+
+        static Stream<Arguments> uploadScenarios() {
+            return Stream.of(
+                    Arguments.of("새 이미지 업로드 성공", false, false, null),
+                    Arguments.of("기존 이미지 교체 성공", true, false, null),
+                    Arguments.of("파일 저장 실패", false, true, CustomException.class)
+            );
+        }
+
+        @Test
+        @DisplayName("파일 검증 실패 시 예외 발생")
+        void uploadProfileImage_FileValidationFails() throws IOException {
+            // given
+            doThrow(new CustomException(CommonErrorCode.INVALID_FILE_TYPE))
+                    .when(fileStorageService).validateFile(mockFile);
+
+            // when & then
+            assertThrows(CustomException.class,
+                    () -> profileImageService.uploadProfileImage(TEST_USER_ID, mockFile));
+
+            verify(userService, never()).findUserById(anyLong());
+            verify(profileImageRepository, never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteProfileImage 테스트")
+    class DeleteProfileImageTest {
+
+        @ParameterizedTest(name = "[{index}] {0}")
+        @MethodSource("deleteScenarios")
+        @DisplayName("다양한 삭제 시나리오")
+        void deleteProfileImage_VariousScenarios(
+                String description,
+                boolean imageExists,
+                boolean isOwner,
+                ProfileErrorCode expectedErrorCode) {
+
+            // given
+            if (imageExists) {
+                Long ownerId = isOwner ? TEST_USER_ID : 999L;
+                ProfileImage profileImage = TestDataBuilder.createMockProfileImage(TEST_IMAGE_ID, ownerId, "test.jpg");
+                when(profileImageRepository.findById(TEST_IMAGE_ID)).thenReturn(Optional.of(profileImage));
+            } else {
+                when(profileImageRepository.findById(TEST_IMAGE_ID)).thenReturn(Optional.empty());
+            }
+
+            // when & then
+            if (!imageExists || !isOwner) {
+                CustomException exception = assertThrows(CustomException.class,
+                        () -> profileImageService.deleteProfileImage(TEST_USER_ID, TEST_IMAGE_ID));
+                assertThat(exception.getErrorCode()).isEqualTo(expectedErrorCode);
+                verify(profileImageRepository, never()).delete(any());
+            } else {
+                profileImageService.deleteProfileImage(TEST_USER_ID, TEST_IMAGE_ID);
+                verify(profileImageRepository).delete(any(ProfileImage.class));
+            }
+        }
+
+        static Stream<Arguments> deleteScenarios() {
+            return Stream.of(
+                    Arguments.of("정상 삭제", true, true, null),
+                    Arguments.of("이미지 없음", false, true, ProfileErrorCode.PROFILE_IMAGE_NOT_FOUND),
+                    Arguments.of("권한 없음", true, false, ProfileErrorCode.PROFILE_IMAGE_ACCESS_DENIED)
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("findProfileImageByUserId 테스트")
+    class FindProfileImageByUserIdTest {
+
+        @ParameterizedTest(name = "[{index}] {0}")
+        @MethodSource("findByUserIdScenarios")
+        @DisplayName("다양한 조회 시나리오")
+        void findProfileImageByUserId_VariousScenarios(
+                String description,
+                boolean hasProfile,
+                boolean hasProfileImage,
+                boolean shouldThrowException) {
+
+            // given
+            User mockUser = mock(User.class);
+            when(mockUser.getId()).thenReturn(TEST_USER_ID);
+            when(userService.findUserById(TEST_USER_ID)).thenReturn(mockUser);
+
+            if (hasProfile) {
+                Profile mockProfile = mock(Profile.class);
+                when(mockUser.getProfile()).thenReturn(mockProfile);
+
+                if (hasProfileImage) {
+                    ProfileImage mockProfileImage = TestDataBuilder.createMockProfileImage(TEST_IMAGE_ID, TEST_USER_ID, "test.jpg");
+                    when(mockProfile.getProfileImage()).thenReturn(mockProfileImage);
+                } else {
+                    when(mockProfile.getProfileImage()).thenReturn(null);
+                }
+            } else {
+                when(mockUser.getProfile()).thenReturn(null);
+            }
+
+            // when & then
+            if (shouldThrowException) {
+                CustomException exception = assertThrows(CustomException.class,
+                        () -> profileImageService.findProfileImageByUserId(TEST_USER_ID));
+                assertThat(exception.getErrorCode()).isEqualTo(ProfileErrorCode.PROFILE_IMAGE_NOT_FOUND);
+            } else {
+                ProfileImage result = profileImageService.findProfileImageByUserId(TEST_USER_ID);
+                assertThat(result).isNotNull();
+            }
+        }
+
+        static Stream<Arguments> findByUserIdScenarios() {
+            return Stream.of(
+                    Arguments.of("정상 조회", true, true, false),
+                    Arguments.of("프로필 없음", false, false, true),
+                    Arguments.of("프로필 이미지 없음", true, false, true)
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("findProfileImageById 테스트")
+    class FindProfileImageByIdTest {
+
+        @ParameterizedTest(name = "[{index}] 이미지 존재: {0}")
+        @ValueSource(booleans = {true, false})
+        @DisplayName("ID로 프로필 이미지 조회")
+        void findProfileImageById_VariousScenarios(boolean imageExists) {
+            // given
+            if (imageExists) {
+                ProfileImage mockProfileImage = TestDataBuilder.createMockProfileImage(TEST_IMAGE_ID, TEST_USER_ID, "test.jpg");
+                when(profileImageRepository.findById(TEST_IMAGE_ID)).thenReturn(Optional.of(mockProfileImage));
+            } else {
+                when(profileImageRepository.findById(TEST_IMAGE_ID)).thenReturn(Optional.empty());
+            }
+
+            // when & then
+            if (imageExists) {
+                ProfileImage result = profileImageService.findProfileImageById(TEST_IMAGE_ID);
+                assertThat(result).isNotNull();
+            } else {
+                CustomException exception = assertThrows(CustomException.class,
+                        () -> profileImageService.findProfileImageById(TEST_IMAGE_ID));
+                assertThat(exception.getErrorCode()).isEqualTo(ProfileErrorCode.PROFILE_IMAGE_NOT_FOUND);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("getDefaultProfileImage 테스트")
+    class GetDefaultProfileImageTest {
+
+        @ParameterizedTest(name = "[{index}] 기본 이미지 존재: {0}")
+        @ValueSource(booleans = {true, false})
+        @DisplayName("기본 프로필 이미지 조회")
+        void getDefaultProfileImage_VariousScenarios(boolean defaultImageExists) {
+            // given
+            if (defaultImageExists) {
+                ProfileImage mockProfileImage = TestDataBuilder.createMockProfileImage(TEST_IMAGE_ID, null, TEST_DEFAULT_FILENAME);
+                when(profileImageRepository.findByOriginalNameAndUserIsNull(TEST_DEFAULT_FILENAME))
+                        .thenReturn(Optional.of(mockProfileImage));
+            } else {
+                when(profileImageRepository.findByOriginalNameAndUserIsNull(TEST_DEFAULT_FILENAME))
+                        .thenReturn(Optional.empty());
+            }
+
+            // when & then
+            if (defaultImageExists) {
+                ProfileImage result = profileImageService.getDefaultProfileImage();
+                assertThat(result).isNotNull();
+            } else {
+                CustomException exception = assertThrows(CustomException.class,
+                        () -> profileImageService.getDefaultProfileImage());
+                assertThat(exception.getErrorCode()).isEqualTo(ProfileErrorCode.PROFILE_IMAGE_NOT_FOUND);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("registerDefaultProfileImage 테스트")
+    class RegisterDefaultProfileImageTest {
+
+        @Test
+        @DisplayName("기본 프로필 이미지가 이미 존재하는 경우")
+        void registerDefaultProfileImage_AlreadyExists() {
+            // given
+            ProfileImage existingImage = TestDataBuilder.createMockProfileImage(TEST_IMAGE_ID, null, TEST_DEFAULT_FILENAME);
+            when(profileImageRepository.findByOriginalNameAndUserIsNull(TEST_DEFAULT_FILENAME))
+                    .thenReturn(Optional.of(existingImage));
+
+            ProfileImageResponse expectedResponse = ProfileImageResponse.builder()
+                    .originalFileName(TEST_DEFAULT_FILENAME)
+                    .build();
+
+            try (MockedStatic<ProfileImageResponse> mockedResponse = mockStatic(ProfileImageResponse.class)) {
+                mockedResponse.when(() -> ProfileImageResponse.from(existingImage))
+                        .thenReturn(expectedResponse);
+
+                // when
+                ProfileImageResponse result = profileImageService.registerDefaultProfileImage();
+
+                // then
+                assertThat(result).isEqualTo(expectedResponse);
+                verify(profileImageRepository, never()).save(any());
+            }
+        }
+
+        @Test
+        @DisplayName("새로운 기본 프로필 이미지 등록 성공")
+        void registerDefaultProfileImage_NewRegistration_Success() throws IOException {
+            // given
+            when(profileImageRepository.findByOriginalNameAndUserIsNull(TEST_DEFAULT_FILENAME))
+                    .thenReturn(Optional.empty());
+
+            // 실제 테스트용 파일 생성
+            String testDir = "test-default/";
+            File testDirectory = new File(testDir);
+            testDirectory.mkdirs();
+            File testFile = new File(testDir + TEST_DEFAULT_FILENAME);
+            testFile.createNewFile();
+
+            ReflectionTestUtils.setField(profileImageService, "profileImageDir", testDir);
+
+            ProfileImage savedImage = TestDataBuilder.createMockProfileImage(TEST_IMAGE_ID, null, TEST_DEFAULT_FILENAME);
+            when(profileImageRepository.save(any(ProfileImage.class))).thenReturn(savedImage);
+
+            ProfileImageResponse expectedResponse = ProfileImageResponse.builder()
+                    .id(TEST_IMAGE_ID)
+                    .originalFileName(TEST_DEFAULT_FILENAME)
+                    .storedFileName(TEST_DEFAULT_FILENAME)
+                    .imageUrl(TEST_URL_PREFIX + TEST_DEFAULT_FILENAME)
+                    .contentType("image/png")
+                    .fileSize(testFile.length())
+                    .build();
+
+            try (MockedStatic<ProfileImageResponse> mockedResponse = mockStatic(ProfileImageResponse.class)) {
+                mockedResponse.when(() -> ProfileImageResponse.from(savedImage))
+                        .thenReturn(expectedResponse);
+
+                // when
+                ProfileImageResponse result = profileImageService.registerDefaultProfileImage();
+
+                // then
+                assertThat(result).isEqualTo(expectedResponse);
+                verify(profileImageRepository).save(any(ProfileImage.class));
+
+            } finally {
+                testFile.delete();
+                testDirectory.delete();
+            }
+        }
+
+        @Test
+        @DisplayName("기본 프로필 이미지 파일이 존재하지 않는 경우")
+        void registerDefaultProfileImage_FileNotExists() {
+            // given
+            when(profileImageRepository.findByOriginalNameAndUserIsNull(TEST_DEFAULT_FILENAME))
+                    .thenReturn(Optional.empty());
+
+            ReflectionTestUtils.setField(profileImageService, "profileImageDir", "non-existent-dir/");
+
+            // when & then
+            CustomException exception = assertThrows(CustomException.class,
+                    () -> profileImageService.registerDefaultProfileImage());
+            assertThat(exception.getErrorCode()).isEqualTo(ProfileErrorCode.IMAGE_UPLOAD_ERROR);
+        }
+    }
+
+
+}

--- a/src/test/java/com/mindmate/mindmate_server/user/service/UserServiceTest.java
+++ b/src/test/java/com/mindmate/mindmate_server/user/service/UserServiceTest.java
@@ -1,173 +1,324 @@
-//package com.mindmate.mindmate_server.user.service;
-//
-//import com.mindmate.mindmate_server.global.exception.AuthErrorCode;
-//import com.mindmate.mindmate_server.global.exception.CustomException;
-//import com.mindmate.mindmate_server.global.exception.UserErrorCode;
-//import com.mindmate.mindmate_server.user.domain.RoleType;
-//import com.mindmate.mindmate_server.user.domain.User;
-//import com.mindmate.mindmate_server.user.repository.UserRepository;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Nested;
-//import org.junit.jupiter.api.Test;
-//import org.junit.jupiter.api.extension.ExtendWith;
-//import org.mockito.InjectMocks;
-//import org.mockito.Mock;
-//import org.mockito.junit.jupiter.MockitoExtension;
-//
-//import java.util.Optional;
-//
-//import static org.junit.jupiter.api.Assertions.*;
-//import static org.mockito.ArgumentMatchers.any;
-//import static org.mockito.Mockito.verify;
-//import static org.mockito.Mockito.when;
-//
-//@ExtendWith(MockitoExtension.class)
-//class UserServiceTest {
-//    @Mock private UserRepository userRepository;
-//
-//    @InjectMocks
-//    private UserServiceImpl userService;
-//
-//    @Nested
-//    @DisplayName("사용자 조회 테스트")
-//    class FindUserTest {
-//        @Test
-//        @DisplayName("ID로 사용자 조회 성공")
-//        void findUserById_Success() {
-//            // given
-//            Long userId = 1L;
-//            User expectedUser = createUser();
-//
-//            when(userRepository.findById(userId)).thenReturn(Optional.of(expectedUser));
-//
-//            // when
-//            User foundUser = userService.findUserById(userId);
-//
-//            // then
-//            assertNotNull(foundUser);
-//            assertEquals(expectedUser.getEmail(), foundUser.getEmail());
-//            verify(userRepository).findById(userId);
-//        }
-//
-//        @Test
-//        @DisplayName("존재하지 않는 ID로 조회 시 예외 발생")
-//        void findUserById_UserNotFound() {
-//            // given
-//            Long userId = 999L;
-//
-//            when(userRepository.findById(userId)).thenReturn(Optional.empty());
-//
-//            // when & then
-//            CustomException exception = assertThrows(CustomException.class, () -> userService.findUserById(userId));
-//            assertEquals(UserErrorCode.USER_NOT_FOUND, exception.getErrorCode());
-//            // then
-//        }
-//    }
-//
-//    @Nested
-//    @DisplayName("이메일 관련 테스트")
-//    class EmailVerificationTest {
-//        @Test
-//        @DisplayName("이메일로 사용자 조회 성공")
-//        void findByEmail_Success() {
-//            // given
-//            String email = "test@example.com";
-//            User expectedUser = createUser();
-//
-//            when(userRepository.findByEmail(email)).thenReturn(Optional.of(expectedUser));
-//
-//            // when
-//            User foundUser = userService.findByEmail(email);
-//
-//            // then
-//            assertNotNull(foundUser);
-//            assertEquals(email, foundUser.getEmail());
-//            verify(userRepository).findByEmail(email);
-//        }
-//
-//        @Test
-//        @DisplayName("존재하지 않는 이메일로 사용자 조회 실패")
-//        void findByEmail_UserNotFound() {
-//            // given
-//            String email = "nonexist@example.com";
-//            when(userRepository.findByEmail(email)).thenReturn(Optional.empty());
-//
-//            // when & then
-//            CustomException exception = assertThrows(CustomException.class, () -> userService.findByEmail(email));
-//            assertEquals(UserErrorCode.USER_NOT_FOUND, exception.getErrorCode());
-//        }
-//
-//        @Test
-//        @DisplayName("이메일 존재 여부 확인 - 존재하는 경우")
-//        void existsByEmail_True() {
-//            // given
-//            String email = "test@example.com";
-//            when(userRepository.existsByEmail(email)).thenReturn(true);
-//
-//            // when
-//            boolean exists = userService.existsByEmail(email);
-//
-//            // then
-//            assertTrue(exists);
-//            verify(userRepository).existsByEmail(email);
-//        }
-//
-//        @Test
-//        @DisplayName("토큰으로 사용자 조회 성공")
-//        void findVerificationToken_Success() {
-//            // given
-//            String token = "valid-token";
-//            User expectedUser = createUser();
-//
-//            when(userRepository.findByVerificationToken(token)).thenReturn(Optional.of(expectedUser));
-//
-//            // when
-//            User foundUser = userService.findVerificationToken(token);
-//
-//            // then
-//            assertNotNull(foundUser);
-//            verify(userRepository).findByVerificationToken(token);
-//        }
-//
-//        @Test
-//        @DisplayName("잘못된 토큰으로 조히 시 예외 발생")
-//        void findVerificationToken_InvalidToken() {
-//            // given
-//            String token = "invalid-token";
-//
-//            when(userRepository.findByVerificationToken(token)).thenReturn(Optional.empty());
-//
-//            // when & then
-//            CustomException exception = assertThrows(CustomException.class, () -> userService.findVerificationToken(token));
-//            assertEquals(AuthErrorCode.INVALID_TOKEN, exception.getErrorCode());
-//        }
-//    }
-//
-//    @Nested
-//    @DisplayName("사용자 저장 테스트")
-//    class SaveUserTest {
-//        @Test
-//        @DisplayName("사용자 저장 성공")
-//        void save_Success() {
-//            // given
-//            User user = createUser();
-//            when(userRepository.save(any(User.class))).thenReturn(user);
-//
-//            // when
-//            userService.save(user);
-//
-//            // then
-//            verify(userRepository).save(user);
-//        }
-//    }
-//
-//
-//
-//    private User createUser() {
-//        return User.builder()
-//                .email("test@example.com")
-//                .password("password")
-//                .role(RoleType.ROLE_USER)
-//                .build();
-//    }
-//}
+package com.mindmate.mindmate_server.user.service;
+
+import com.mindmate.mindmate_server.auth.domain.AuthProvider;
+import com.mindmate.mindmate_server.global.exception.CustomException;
+import com.mindmate.mindmate_server.global.exception.UserErrorCode;
+import com.mindmate.mindmate_server.user.domain.RoleType;
+import com.mindmate.mindmate_server.user.domain.User;
+import com.mindmate.mindmate_server.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class UserServiceImplTest {
+
+    @Mock private UserRepository userRepository;
+
+    @InjectMocks
+    private UserServiceImpl userService;
+
+    private User mockUser;
+    private final Long TEST_USER_ID = 1L;
+    private final String TEST_EMAIL = "test@example.com";
+
+    @BeforeEach
+    void setUp() {
+        mockUser = User.builder()
+                .email(TEST_EMAIL)
+                .provider(AuthProvider.GOOGLE)
+                .providerId("google123")
+                .role(RoleType.ROLE_USER)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("findUserById 테스트")
+    class FindUserByIdTest {
+
+        @Test
+        @DisplayName("정상적으로 사용자를 찾는 경우")
+        void findUserById_Success() {
+            // given
+            when(userRepository.findById(TEST_USER_ID)).thenReturn(Optional.of(mockUser));
+
+            // when
+            User result = userService.findUserById(TEST_USER_ID);
+
+            // then
+            assertThat(result).isEqualTo(mockUser);
+            verify(userRepository).findById(TEST_USER_ID);
+        }
+
+        @Test
+        @DisplayName("사용자를 찾지 못한 경우 예외 발생")
+        void findUserById_UserNotFound_ThrowsException() {
+            // given
+            when(userRepository.findById(TEST_USER_ID)).thenReturn(Optional.empty());
+
+            // when & then
+            CustomException exception = assertThrows(CustomException.class,
+                    () -> userService.findUserById(TEST_USER_ID));
+
+            assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_FOUND);
+            verify(userRepository).findById(TEST_USER_ID);
+        }
+    }
+
+    @Nested
+    @DisplayName("findByEmail 테스트")
+    class FindByEmailTest {
+
+        @Test
+        @DisplayName("정상적으로 이메일로 사용자를 찾는 경우")
+        void findByEmail_Success() {
+            // given
+            when(userRepository.findByEmail(TEST_EMAIL)).thenReturn(Optional.of(mockUser));
+
+            // when
+            User result = userService.findByEmail(TEST_EMAIL);
+
+            // then
+            assertThat(result).isEqualTo(mockUser);
+            verify(userRepository).findByEmail(TEST_EMAIL);
+        }
+
+        @Test
+        @DisplayName("이메일로 사용자를 찾지 못한 경우 예외 발생")
+        void findByEmail_UserNotFound_ThrowsException() {
+            // given
+            when(userRepository.findByEmail(TEST_EMAIL)).thenReturn(Optional.empty());
+
+            // when & then
+            CustomException exception = assertThrows(CustomException.class,
+                    () -> userService.findByEmail(TEST_EMAIL));
+
+            assertThat(exception.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_FOUND);
+            verify(userRepository).findByEmail(TEST_EMAIL);
+        }
+
+        @ParameterizedTest(name = "[{index}] 이메일: {0}")
+        @ValueSource(strings = {"test@example.com", "user@domain.co.kr", "admin@test.org"})
+        @DisplayName("다양한 이메일 형식으로 사용자 조회")
+        void findByEmail_VariousEmailFormats(String email) {
+            // given
+            when(userRepository.findByEmail(email)).thenReturn(Optional.of(mockUser));
+
+            // when
+            User result = userService.findByEmail(email);
+
+            // then
+            assertThat(result).isEqualTo(mockUser);
+            verify(userRepository).findByEmail(email);
+        }
+    }
+
+    @Nested
+    @DisplayName("existsByEmail 테스트")
+    class ExistsByEmailTest {
+
+        @ParameterizedTest(name = "[{index}] 이메일 존재 여부: {0}")
+        @ValueSource(booleans = {true, false})
+        @DisplayName("이메일 존재 여부 확인")
+        void existsByEmail_ParamTest(boolean exists) {
+            // given
+            when(userRepository.existsByEmail(TEST_EMAIL)).thenReturn(exists);
+
+            // when
+            boolean result = userService.existsByEmail(TEST_EMAIL);
+
+            // then
+            assertThat(result).isEqualTo(exists);
+            verify(userRepository).existsByEmail(TEST_EMAIL);
+        }
+    }
+
+    @Nested
+    @DisplayName("save 테스트")
+    class SaveTest {
+
+        @Test
+        @DisplayName("사용자 저장 성공")
+        void save_Success() {
+            // given
+            User savedUser = User.builder()
+                    .email("saved@example.com")
+                    .provider(AuthProvider.GOOGLE)
+                    .providerId("google456")
+                    .role(RoleType.ROLE_USER)
+                    .build();
+
+            when(userRepository.save(mockUser)).thenReturn(savedUser);
+
+            // when
+            User result = userService.save(mockUser);
+
+            // then
+            assertThat(result).isEqualTo(savedUser);
+            verify(userRepository).save(mockUser);
+        }
+    }
+
+    @Nested
+    @DisplayName("findByCurrentRoleAndSuspensionEndTimeBefore 테스트")
+    class FindByCurrentRoleAndSuspensionEndTimeBeforeTest {
+
+        @Test
+        @DisplayName("역할과 정지 종료 시간으로 사용자 목록 조회")
+        void findByCurrentRoleAndSuspensionEndTimeBefore_Success() {
+            // given
+            RoleType roleType = RoleType.ROLE_SUSPENDED;
+            LocalDateTime time = LocalDateTime.now();
+            List<User> expectedUsers = Arrays.asList(mockUser);
+
+            when(userRepository.findByCurrentRoleAndSuspensionEndTimeBefore(roleType, time))
+                    .thenReturn(expectedUsers);
+
+            // when
+            List<User> result = userService.findByCurrentRoleAndSuspensionEndTimeBefore(roleType, time);
+
+            // then
+            assertThat(result).isEqualTo(expectedUsers);
+            verify(userRepository).findByCurrentRoleAndSuspensionEndTimeBefore(roleType, time);
+        }
+
+        @Test
+        @DisplayName("조건에 맞는 사용자가 없는 경우 빈 리스트 반환")
+        void findByCurrentRoleAndSuspensionEndTimeBefore_EmptyList() {
+            // given
+            RoleType roleType = RoleType.ROLE_SUSPENDED;
+            LocalDateTime time = LocalDateTime.now();
+            List<User> emptyList = Collections.emptyList();
+
+            when(userRepository.findByCurrentRoleAndSuspensionEndTimeBefore(roleType, time))
+                    .thenReturn(emptyList);
+
+            // when
+            List<User> result = userService.findByCurrentRoleAndSuspensionEndTimeBefore(roleType, time);
+
+            // then
+            assertThat(result).isEmpty();
+            verify(userRepository).findByCurrentRoleAndSuspensionEndTimeBefore(roleType, time);
+        }
+    }
+
+    @Nested
+    @DisplayName("findAllUserIds 테스트")
+    class FindAllUserIdsTest {
+
+        @Test
+        @DisplayName("모든 사용자 ID 조회 성공")
+        void findAllUserIds_Success() {
+            // given
+            List<Long> expectedIds = Arrays.asList(1L, 2L, 3L, 4L, 5L);
+            when(userRepository.findAllUserIds()).thenReturn(expectedIds);
+
+            // when
+            List<Long> result = userService.findAllUserIds();
+
+            // then
+            assertThat(result).isEqualTo(expectedIds);
+            assertThat(result).hasSize(5);
+            verify(userRepository).findAllUserIds();
+        }
+
+        @Test
+        @DisplayName("사용자가 없는 경우 빈 리스트 반환")
+        void findAllUserIds_EmptyList() {
+            // given
+            List<Long> emptyList = Collections.emptyList();
+            when(userRepository.findAllUserIds()).thenReturn(emptyList);
+
+            // when
+            List<Long> result = userService.findAllUserIds();
+
+            // then
+            assertThat(result).isEmpty();
+            verify(userRepository).findAllUserIds();
+        }
+    }
+
+    @Nested
+    @DisplayName("findByEmailOptional 테스트")
+    class FindByEmailOptionalTest {
+
+        @Test
+        @DisplayName("이메일로 사용자를 찾은 경우 Optional 반환")
+        void findByEmailOptional_UserFound() {
+            // given
+            when(userRepository.findByEmail(TEST_EMAIL)).thenReturn(Optional.of(mockUser));
+
+            // when
+            Optional<User> result = userService.findByEmailOptional(TEST_EMAIL);
+
+            // then
+            assertThat(result).isPresent();
+            assertThat(result.get()).isEqualTo(mockUser);
+            verify(userRepository).findByEmail(TEST_EMAIL);
+        }
+
+        @Test
+        @DisplayName("이메일로 사용자를 찾지 못한 경우 빈 Optional 반환")
+        void findByEmailOptional_UserNotFound() {
+            // given
+            when(userRepository.findByEmail(TEST_EMAIL)).thenReturn(Optional.empty());
+
+            // when
+            Optional<User> result = userService.findByEmailOptional(TEST_EMAIL);
+
+            // then
+            assertThat(result).isEmpty();
+            verify(userRepository).findByEmail(TEST_EMAIL);
+        }
+
+        @ParameterizedTest(name = "[{index}] 이메일: {0}, 존재 여부: {1}")
+        @MethodSource("emailOptionalScenarios")
+        @DisplayName("다양한 이메일 시나리오로 Optional 조회")
+        void findByEmailOptional_ParamTest(String email, boolean userExists) {
+            // given
+            Optional<User> expectedResult = userExists ? Optional.of(mockUser) : Optional.empty();
+            when(userRepository.findByEmail(email)).thenReturn(expectedResult);
+
+            // when
+            Optional<User> result = userService.findByEmailOptional(email);
+
+            // then
+            assertThat(result).isEqualTo(expectedResult);
+            verify(userRepository).findByEmail(email);
+        }
+
+        static Stream<Arguments> emailOptionalScenarios() {
+            return Stream.of(
+                    Arguments.of("existing@example.com", true),
+                    Arguments.of("nonexistent@example.com", false),
+                    Arguments.of("test@domain.co.kr", true),
+                    Arguments.of("invalid@test.org", false)
+            );
+        }
+    }
+
+}


### PR DESCRIPTION
## 🛰️ Issue Number

## 🪐 작업 내용
1. userService
2. adminUserSuspensionService
3. FileStorageService
4. profileImageService
5. 로그인 시 사용자 역할 데이터 추가
6. 컨슈머 재시도 지수 백오프 추가