### PR TITLE
[Fix#193] 매칭 및 익명 관련 로직 변경

### DIFF
--- a/src/main/java/com/mindmate/mindmate_server/matching/dto/AutoMatchingRequest.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/dto/AutoMatchingRequest.java
@@ -14,6 +14,4 @@ import lombok.NoArgsConstructor;
 public class AutoMatchingRequest {
 
     private InitiatorType userRole;
-    private boolean anonymous;
-    private boolean showDepartment;
 }

--- a/src/main/java/com/mindmate/mindmate_server/matching/dto/WaitingUserRequest.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/dto/WaitingUserRequest.java
@@ -14,5 +14,4 @@ public class WaitingUserRequest {
 
     @Size(max = 100)
     private String message;
-    private boolean anonymous;
 }

--- a/src/main/java/com/mindmate/mindmate_server/matching/service/MatchingServiceImpl.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/service/MatchingServiceImpl.java
@@ -108,7 +108,7 @@ public class MatchingServiceImpl implements MatchingService {
             public void afterCommit() {
                 redisMatchingService.incrementUserActiveMatchingCount(userId);
 
-                sendMatchingAppliedNotification(user, matching, request.isAnonymous());
+                sendMatchingAppliedNotification(user, matching, matching.isAnonymous());
             }
         });
 
@@ -188,7 +188,7 @@ public class MatchingServiceImpl implements MatchingService {
         WaitingUser waitingUser = WaitingUser.builder()
                 .waitingUser(user)
                 .matchingType(MatchingType.AUTO_RANDOM)
-                .anonymous(request.isAnonymous())
+                .anonymous(matching.isAnonymous())
                 .build();
 
         matching.addWaitingUser(waitingUser);
@@ -431,7 +431,7 @@ public class MatchingServiceImpl implements MatchingService {
                 .waitingUser(user)
                 .message(request.getMessage())
                 .matchingType(MatchingType.MANUAL)
-                .anonymous(request.isAnonymous())
+                .anonymous(matching.isAnonymous())
                 .build();
 
         matching.addWaitingUser(waitingUser);

--- a/src/main/java/com/mindmate/mindmate_server/matching/service/RedisMatchingService.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/service/RedisMatchingService.java
@@ -76,7 +76,6 @@ public class RedisMatchingService {
         DEPARTMENT_TO_COLLEGE_MAP.put("국제학부", "인문대학");
     }
 
-
     public void addMatchingToAvailableSet(Matching matching) {
         String setKey = getAvailableMatchingSetKey(matching.getCreatorRole());
         redisTemplate.opsForSet().add(setKey, matching.getId().toString());
@@ -114,7 +113,6 @@ public class RedisMatchingService {
     }
 
     public void cleanupMatchingKeys(Matching matching) {
-
         if (!matching.isOpen()) {
             String setKey = getAvailableMatchingSetKey(matching.getCreatorRole());
             redisTemplate.opsForSet().remove(setKey, matching.getId().toString());
@@ -221,6 +219,10 @@ public class RedisMatchingService {
                     continue;
                 }
 
+                if (matching.isCreator(user)) {
+                    continue;
+                }
+
                 double score = calculateMatchingScore(user, matching);
                 scoredMatches.put(matchingId, score);
             } catch (Exception e) {
@@ -256,5 +258,4 @@ public class RedisMatchingService {
     private void setExpiry(String key, int hours) {
         redisTemplate.expire(key, hours, TimeUnit.HOURS);
     }
-
 }

--- a/src/main/java/com/mindmate/mindmate_server/review/dto/ReviewRequest.java
+++ b/src/main/java/com/mindmate/mindmate_server/review/dto/ReviewRequest.java
@@ -22,5 +22,4 @@ public class ReviewRequest {
     @Size(max=200)
     private String comment;
     private List<String> tags;
-    private boolean anonymous;
 }

--- a/src/main/java/com/mindmate/mindmate_server/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/mindmate/mindmate_server/review/service/ReviewServiceImpl.java
@@ -112,7 +112,7 @@ public class ReviewServiceImpl implements ReviewService{
                 .reviewedProfile(reviewedProfile)
                 .rating(request.getRating())
                 .comment(request.getComment())
-                .anonymous(request.isAnonymous())
+                .anonymous(chatRoom.getMatching().isAnonymous())
                 .build();
 
         return reviewRepository.save(review);

--- a/src/test/java/com/mindmate/mindmate_server/matching/service/MatchingServiceImplTest.java
+++ b/src/test/java/com/mindmate/mindmate_server/matching/service/MatchingServiceImplTest.java
@@ -264,7 +264,7 @@ class MatchingServiceImplTest {
         @Test
         @DisplayName("매칭 신청 성공")
         void applyForMatchingSuccess() {
-            WaitingUserRequest request = new WaitingUserRequest("I want to participate", false);
+            WaitingUserRequest request = new WaitingUserRequest("I want to participate");
 
             given(userService.findUserById(2L)).willReturn(applicant);
             given(redisMatchingService.getUserActiveMatchingCount(2L)).willReturn(0);
@@ -289,7 +289,7 @@ class MatchingServiceImplTest {
         @Test
         @DisplayName("자신의 매칭에 신청 시 예외 발생")
         void applyForOwnMatching() {
-            WaitingUserRequest request = new WaitingUserRequest("I want to participate", false);
+            WaitingUserRequest request = new WaitingUserRequest("I want to participate");
 
             given(userService.findUserById(1L)).willReturn(creator);
             given(redisMatchingService.getUserActiveMatchingCount(1L)).willReturn(0);
@@ -307,7 +307,7 @@ class MatchingServiceImplTest {
         @Test
         @DisplayName("활성 매칭 수 초과 시 신청 불가")
         void applyForMatchingExceedLimit() {
-            WaitingUserRequest request = new WaitingUserRequest("I want to participate", false);
+            WaitingUserRequest request = new WaitingUserRequest("I want to participate");
 
             given(userService.findUserById(2L)).willReturn(applicant);
             given(matchingRepository.findById(1L)).willReturn(Optional.of(matching));
@@ -379,8 +379,7 @@ class MatchingServiceImplTest {
         @DisplayName("자동 매칭 신청 성공")
         void autoMatchApplySuccess() {
             AutoMatchingRequest request = new AutoMatchingRequest(
-                    InitiatorType.LISTENER,
-                    false, true
+                    InitiatorType.LISTENER
             );
 
             MatchingServiceImpl spyMatchingService = spy(matchingService);
@@ -409,8 +408,7 @@ class MatchingServiceImplTest {
         @DisplayName("자동 매칭 가능한 상대가 없을 때 예외 발생")
         void autoMatchNoMatchingAvailable() {
             AutoMatchingRequest request = new AutoMatchingRequest(
-                    InitiatorType.LISTENER,
-                    false, true
+                    InitiatorType.LISTENER
             );
 
             given(userService.findUserById(2L)).willReturn(applicant);
@@ -967,7 +965,7 @@ class MatchingServiceImplTest {
             given(matchingRepository.findById(1L)).willReturn(Optional.of(matching));
             given(redisMatchingService.getUserActiveMatchingCount(2L)).willReturn(3);
 
-            WaitingUserRequest request = new WaitingUserRequest("Want to join", false);
+            WaitingUserRequest request = new WaitingUserRequest("Want to join");
 
             assertThatThrownBy(() -> matchingService.applyForMatching(2L, 1L, request))
                     .isInstanceOf(CustomException.class)
@@ -1031,7 +1029,7 @@ class MatchingServiceImplTest {
         @Test
         @DisplayName("시나리오: 자동 매칭 성공 시 즉시 매칭 완료")
         void scenarioAutoMatchingImmediateCompletion() {
-            AutoMatchingRequest request = new AutoMatchingRequest(InitiatorType.LISTENER, false, true);
+            AutoMatchingRequest request = new AutoMatchingRequest(InitiatorType.LISTENER);
             MatchingServiceImpl spyMatchingService = spy(matchingService);
 
             given(userService.findUserById(2L)).willReturn(applicant);
@@ -1062,7 +1060,7 @@ class MatchingServiceImplTest {
 
             verify(redisMatchingService).decrementUserActiveMatchingCount(2L);
 
-            WaitingUserRequest newRequest = new WaitingUserRequest("Want to join again", false);
+            WaitingUserRequest newRequest = new WaitingUserRequest("Want to join again");
             given(userService.findUserById(2L)).willReturn(applicant);
             given(redisMatchingService.getUserActiveMatchingCount(2L)).willReturn(0);
             given(matchingRepository.findById(1L)).willReturn(Optional.of(matching));


### PR DESCRIPTION
## 🛰️ Issue Number
#193 
## 🪐 작업 내용
- 랜덤 매칭 자기자신 매칭되는 오류 해결
- 익명 관련 로직 수정
- 전 : 프론트에서 익명 관련 정보 받음
- 후 : 매칭 익명이면 다 익명으로 처리